### PR TITLE
 Add checkhealth endpoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,5 +44,8 @@ jobs:
       run: |
         poetry run flake8 .
 
+    - name: Start cache service
+      run: docker compose up -d --build cache
+
     - name: Test with pytest
       run: poetry run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,5 @@ jobs:
       run: |
         poetry run flake8 .
 
-    - name: Start redis
-      run: docker compose up -d --build cache
-
     - name: Test with pytest
       run: poetry run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,5 +44,8 @@ jobs:
       run: |
         poetry run flake8 .
 
+    - name: Start redis
+      run: docker compose up -d --build cache
+
     - name: Test with pytest
       run: poetry run pytest

--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ venv.bak/
 
 # Config files
 application.yml
+application-docker.yml
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 ## With docker
 - (optional) Install **[Task](https://taskfile.dev)**
+- Copy `application.example.yml` to `application-docker.yml` and change necessary values
 - Build docker: `docker compose build` or `task build`
 - Run server: `docker compose up -d` or `task up`
 - Stop server: `docker compose down` or `task down`

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,3 +30,8 @@ tasks:
   logs:
     cmds:
       - docker compose logs -f server
+
+  console:
+    aliases: [ c ]
+    cmds:
+      - docker attach pyris-server # using <ctrl-p><ctrl-q> to detach

--- a/app/config.py
+++ b/app/config.py
@@ -3,9 +3,18 @@ from pydantic import BaseModel
 from pyaml_env import parse_config
 
 
+class CacheSettings(BaseModel):
+    class CacheParams(BaseModel):
+        host: str
+        port: int
+
+    hazelcast: CacheParams
+
+
 class Settings(BaseModel):
     class PyrisSettings(BaseModel):
         api_key: str
+        cache: CacheSettings
         llm: dict
 
     pyris: PyrisSettings

--- a/app/config.py
+++ b/app/config.py
@@ -18,10 +18,11 @@ class Settings(BaseModel):
 
     @classmethod
     def get_settings(cls):
+        postfix = "-docker" if "DOCKER" in os.environ else ""
         if "RUN_ENV" in os.environ and os.environ["RUN_ENV"] == "test":
-            file_path = "application.test.yml"
+            file_path = f"application{postfix}.test.yml"
         else:
-            file_path = "application.yml"
+            file_path = f"application{postfix}.yml"
 
         return Settings.parse_obj(parse_config(file_path))
 

--- a/app/config.py
+++ b/app/config.py
@@ -3,15 +3,9 @@ from pydantic import BaseModel
 from pyaml_env import parse_config
 
 
-class RedisSettings(BaseModel):
-    host: str
-    port: int
-
-
 class Settings(BaseModel):
     class PyrisSettings(BaseModel):
         api_key: str
-        redis: RedisSettings
         llm: dict
 
     pyris: PyrisSettings

--- a/app/config.py
+++ b/app/config.py
@@ -3,9 +3,15 @@ from pydantic import BaseModel
 from pyaml_env import parse_config
 
 
+class RedisSettings(BaseModel):
+    host: str
+    port: int
+
+
 class Settings(BaseModel):
     class PyrisSettings(BaseModel):
         api_key: str
+        redis: RedisSettings
         llm: dict
 
     pyris: PyrisSettings

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,9 @@ from fastapi import FastAPI
 from fastapi.responses import ORJSONResponse
 
 from app.routes.messages import router as messages_router
+from app.routes.health import router as health_router
 
 app = FastAPI(default_response_class=ORJSONResponse)
 
 app.include_router(messages_router)
+app.include_router(health_router)

--- a/app/main.py
+++ b/app/main.py
@@ -3,8 +3,15 @@ from fastapi.responses import ORJSONResponse
 
 from app.routes.messages import router as messages_router
 from app.routes.health import router as health_router
+from app.services.hazelcast_client import hazelcast_client
 
 app = FastAPI(default_response_class=ORJSONResponse)
+
+
+@app.on_event("shutdown")
+async def shutdown():
+    hazelcast_client.shutdown()
+
 
 app.include_router(messages_router)
 app.include_router(health_router)

--- a/app/models/dtos.py
+++ b/app/models/dtos.py
@@ -9,6 +9,12 @@ class LLMModel(str, Enum):
     GPT35_TURBO_0613 = "GPT35_TURBO_0613"
 
 
+class LLMStatus(str, Enum):
+    UP = "UP"
+    DOWN = "DOWN"
+    NOT_AVAILABLE = "NOT_AVAILABLE"
+
+
 class ContentType(str, Enum):
     TEXT = "text"
 
@@ -37,3 +43,8 @@ class SendMessageResponse(BaseModel):
 
     used_model: LLMModel = Field(..., alias="usedModel")
     message: Message
+
+
+class ModelStatus(BaseModel):
+    model: LLMModel
+    status: LLMStatus

--- a/app/routes/health.py
+++ b/app/routes/health.py
@@ -1,4 +1,3 @@
-import guidance
 from fastapi import APIRouter, Depends
 
 from app.dependencies import PermissionsValidator
@@ -14,7 +13,6 @@ def checkhealth():
     result = []
 
     for model in LLMModel:
-        guidance.llms.OpenAI.cache.clear()
         circuit_status = CircuitBreaker.get_status(
             func=GuidanceWrapper(model=model).is_up,
             cache_key=model,

--- a/app/routes/health.py
+++ b/app/routes/health.py
@@ -14,7 +14,7 @@ def checkhealth():
 
     for model in LLMModel:
         circuit_status = CircuitBreaker.get_status(
-            func=GuidanceWrapper(model=model).is_up,
+            checkhealth_func=GuidanceWrapper(model=model).is_up,
             cache_key=model,
         )
         status = (

--- a/app/routes/health.py
+++ b/app/routes/health.py
@@ -9,7 +9,7 @@ router = APIRouter()
 
 
 @router.get("/api/v1/health", dependencies=[Depends(PermissionsValidator())])
-def checkhealth():
+def checkhealth() -> list[ModelStatus]:
     result = []
 
     for model in LLMModel:

--- a/app/routes/health.py
+++ b/app/routes/health.py
@@ -1,15 +1,29 @@
+import guidance
 from fastapi import APIRouter, Depends
 
 from app.dependencies import PermissionsValidator
 from app.models.dtos import LLMModel, LLMStatus, ModelStatus
+from app.services.guidance_wrapper import GuidanceWrapper
+from app.services.circuit_breaker import CircuitBreaker
 
 router = APIRouter()
 
 
 @router.get("/api/v1/health", dependencies=[Depends(PermissionsValidator())])
-def check_health():
+def checkhealth():
     result = []
+
     for model in LLMModel:
-        result.append(ModelStatus(model=model, status=LLMStatus.UP))
+        guidance.llms.OpenAI.cache.clear()
+        circuit_status = CircuitBreaker.get_status(
+            GuidanceWrapper(model=model).is_up,
+            key=model,
+        )
+        status = (
+            LLMStatus.UP
+            if circuit_status == CircuitBreaker.Status.CLOSED
+            else LLMStatus.DOWN
+        )
+        result.append(ModelStatus(model=model, status=status))
 
     return result

--- a/app/routes/health.py
+++ b/app/routes/health.py
@@ -16,8 +16,8 @@ def checkhealth():
     for model in LLMModel:
         guidance.llms.OpenAI.cache.clear()
         circuit_status = CircuitBreaker.get_status(
-            GuidanceWrapper(model=model).is_up,
-            key=model,
+            func=GuidanceWrapper(model=model).is_up,
+            cache_key=model,
         )
         status = (
             LLMStatus.UP

--- a/app/routes/health.py
+++ b/app/routes/health.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends
+
+from app.dependencies import PermissionsValidator
+from app.models.dtos import LLMModel, LLMStatus, ModelStatus
+
+router = APIRouter()
+
+
+@router.get("/api/v1/health", dependencies=[Depends(PermissionsValidator())])
+def check_health():
+    result = []
+    for model in LLMModel:
+        result.append(ModelStatus(model=model, status=LLMStatus.UP))
+
+    return result

--- a/app/routes/messages.py
+++ b/app/routes/messages.py
@@ -35,7 +35,7 @@ def send_message(body: SendMessageRequest) -> SendMessageResponse:
     try:
         content = CircuitBreaker.protected_call(
             func=guidance.query,
-            cache_key=body.preferred_model,
+            cache_key=model,
             accepted_exceptions=(KeyError, SyntaxError, IncompleteParseError),
         )
     except KeyError as e:

--- a/app/routes/messages.py
+++ b/app/routes/messages.py
@@ -22,8 +22,9 @@ def send_message(body: SendMessageRequest) -> SendMessageResponse:
 
     try:
         content = CircuitBreaker.protected_call(
-            guidance.query,
-            key=body.preferred_model,
+            func=guidance.query,
+            cache_key=body.preferred_model,
+            accepted_exceptions=(KeyError, ValueError),
         )
     except (KeyError, ValueError) as e:
         raise BadDataException(str(e))

--- a/app/services/cache.py
+++ b/app/services/cache.py
@@ -1,4 +1,82 @@
-from app.config import settings
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta
 
-# TODO
-cache_store = None
+
+class CacheStoreInterface(ABC):
+    @abstractmethod
+    def get(self, key):
+        pass
+
+    @abstractmethod
+    def set(self, key, value, ex=None):
+        pass
+
+    @abstractmethod
+    def expire(self, key, ex):
+        pass
+
+    @abstractmethod
+    def incr(self, key):
+        """Increase the integer value of a key by 1.
+        If the key does not exist, it is set to 0
+        before performing the operation.
+        """
+        pass
+
+    @abstractmethod
+    def flushdb(self):
+        pass
+
+    @abstractmethod
+    def delete(self, key):
+        pass
+
+
+class InMemoryCacheStore(CacheStoreInterface):
+    def __init__(self):
+        self._cache = {}
+
+    def get(self, key):
+        current_time = datetime.now()
+        ttl = self._cache.get(f"{key}:ttl")
+        if ttl and current_time > ttl:
+            del self._cache[key]
+            del self._cache[f"{key}:ttl"]
+            return None
+
+        return self._cache.get(key)
+
+    def set(self, key, value, ex=None):
+        self._cache[key] = value
+        self.expire(key, ex)
+
+    def expire(self, key, ex):
+        if ex is None:
+            ttl = None
+        else:
+            current_time = datetime.now()
+            ttl = current_time + timedelta(seconds=ex)
+
+        self._cache[f"{key}:ttl"] = ttl
+
+    def incr(self, key):
+        value = self.get(key)
+        if value is None:
+            self._cache[key] = 1
+        elif isinstance(value, int):
+            self._cache[key] += 1
+        else:
+            raise TypeError("value is not an integer")
+
+        return self._cache[key]
+
+    def flushdb(self):
+        self._cache = {}
+
+    def delete(self, key):
+        if key in self._cache:
+            del self._cache[key]
+            del self._cache[f"{key}:ttl"]
+
+
+cache_store = InMemoryCacheStore()

--- a/app/services/cache.py
+++ b/app/services/cache.py
@@ -4,20 +4,31 @@ from datetime import datetime, timedelta
 
 class CacheStoreInterface(ABC):
     @abstractmethod
-    def get(self, key):
+    def get(self, name):
+        """
+        Return the value at key ``name``, or None if the key doesn't exist
+        """
         pass
 
     @abstractmethod
-    def set(self, key, value, ex=None):
+    def set(self, name, value, ex=None):
+        """
+        Set the value at key ``name`` to ``value``
+
+        ``ex`` sets an expire flag on key ``name`` for ``ex`` seconds.
+        """
         pass
 
     @abstractmethod
-    def expire(self, key, ex):
+    def expire(self, name, ex):
+        """
+        Set an expire flag on key ``name`` for ``ex`` seconds
+        """
         pass
 
     @abstractmethod
-    def incr(self, key):
-        """Increase the integer value of a key by 1.
+    def incr(self, name):
+        """Increase the integer value of a key ``name`` by 1.
         If the key does not exist, it is set to 0
         before performing the operation.
         """
@@ -25,10 +36,16 @@ class CacheStoreInterface(ABC):
 
     @abstractmethod
     def flushdb(self):
+        """
+        Delete all keys in the current database
+        """
         pass
 
     @abstractmethod
-    def delete(self, key):
+    def delete(self, name):
+        """
+        Delete the key specified by ``name``
+        """
         pass
 
 
@@ -36,47 +53,47 @@ class InMemoryCacheStore(CacheStoreInterface):
     def __init__(self):
         self._cache = {}
 
-    def get(self, key):
+    def get(self, name):
         current_time = datetime.now()
-        ttl = self._cache.get(f"{key}:ttl")
+        ttl = self._cache.get(f"{name}:ttl")
         if ttl and current_time > ttl:
-            del self._cache[key]
-            del self._cache[f"{key}:ttl"]
+            del self._cache[name]
+            del self._cache[f"{name}:ttl"]
             return None
 
-        return self._cache.get(key)
+        return self._cache.get(name)
 
-    def set(self, key, value, ex=None):
-        self._cache[key] = value
-        self.expire(key, ex)
+    def set(self, name, value, ex=None):
+        self._cache[name] = value
+        self.expire(name, ex)
 
-    def expire(self, key, ex):
+    def expire(self, name, ex):
         if ex is None:
             ttl = None
         else:
             current_time = datetime.now()
             ttl = current_time + timedelta(seconds=ex)
 
-        self._cache[f"{key}:ttl"] = ttl
+        self._cache[f"{name}:ttl"] = ttl
 
-    def incr(self, key):
-        value = self.get(key)
+    def incr(self, name):
+        value = self.get(name)
         if value is None:
-            self._cache[key] = 1
+            self._cache[name] = 1
         elif isinstance(value, int):
-            self._cache[key] += 1
+            self._cache[name] += 1
         else:
             raise TypeError("value is not an integer")
 
-        return self._cache[key]
+        return self._cache[name]
 
     def flushdb(self):
         self._cache = {}
 
-    def delete(self, key):
-        if key in self._cache:
-            del self._cache[key]
-            del self._cache[f"{key}:ttl"]
+    def delete(self, name):
+        if name in self._cache:
+            del self._cache[name]
+            del self._cache[f"{name}:ttl"]
 
 
 cache_store = InMemoryCacheStore()

--- a/app/services/cache.py
+++ b/app/services/cache.py
@@ -1,0 +1,8 @@
+from redis import Redis
+from app.config import settings
+
+cache_store = Redis(
+    host=settings.pyris.redis.host,
+    port=settings.pyris.redis.port,
+    decode_responses=True,
+)

--- a/app/services/cache.py
+++ b/app/services/cache.py
@@ -8,7 +8,10 @@ class CacheStoreInterface(ABC):
     @abstractmethod
     def get(self, name: str):
         """
-        Return the value at key ``name``, or None if the key doesn't exist
+        Get the value at key ``name``
+
+        Returns:
+            The value at key ``name``, or None if the key doesn't exist
         """
         pass
 
@@ -29,10 +32,17 @@ class CacheStoreInterface(ABC):
         pass
 
     @abstractmethod
-    def incr(self, name: str):
-        """Increase the integer value of a key ``name`` by 1.
+    def incr(self, name: str) -> int:
+        """
+        Increase the integer value of a key ``name`` by 1.
         If the key does not exist, it is set to 0
         before performing the operation.
+
+        Returns:
+            The value of key ``name`` after the increment
+
+        Raises:
+            TypeError: if cache value is not an integer
         """
         pass
 
@@ -59,7 +69,7 @@ class InMemoryCacheStore(CacheStoreInterface):
     def __init__(self):
         self._cache: dict[str, Union[InMemoryCacheStore.CacheValue, None]] = {}
 
-    def get(self, name: str):
+    def get(self, name: str) -> Union[Any, None]:
         current_time = datetime.now()
         data = self._cache.get(name)
         if data is None:
@@ -84,7 +94,7 @@ class InMemoryCacheStore(CacheStoreInterface):
             return
         data.ttl = ttl
 
-    def incr(self, name: str):
+    def incr(self, name: str) -> int:
         value = self.get(name)
         if value is None:
             self._cache[name] = InMemoryCacheStore.CacheValue(

--- a/app/services/cache.py
+++ b/app/services/cache.py
@@ -1,8 +1,4 @@
-from redis import Redis
 from app.config import settings
 
-cache_store = Redis(
-    host=settings.pyris.redis.host,
-    port=settings.pyris.redis.port,
-    decode_responses=True,
-)
+# TODO
+cache_store = None

--- a/app/services/circuit_breaker.py
+++ b/app/services/circuit_breaker.py
@@ -1,0 +1,60 @@
+from enum import Enum
+from app.services.cache import cache_store
+
+
+class CircuitBreaker:
+    MAX_FAILURES = 3
+    STATUS_CACHE_CLOSED_TTL = 300
+    STATUS_CACHE_OPEN_TTL = 30
+
+    class Status(str, Enum):
+        OPEN = "OPEN"
+        CLOSED = "CLOSED"
+
+    @classmethod
+    def protected_call(cls, func, key):
+        num_failures_key = f"{key}:num_failures"
+        status_key = f"{key}:status"
+
+        status = cache_store.get(status_key)
+        if status == cls.Status.OPEN:
+            raise ValueError("Too many failures! Please try again later.")
+
+        try:
+            return func()
+        except (KeyError, ValueError) as e:
+            raise e
+        except Exception as e:
+            num_failures = cache_store.incr(num_failures_key)
+            cache_store.expire(num_failures_key, cls.STATUS_CACHE_OPEN_TTL)
+            if num_failures >= cls.MAX_FAILURES:
+                cache_store.set(
+                    status_key, cls.Status.OPEN, ex=cls.STATUS_CACHE_OPEN_TTL
+                )
+
+            raise e
+
+    @classmethod
+    def get_status(cls, func, key):
+        status_key = f"{key}:status"
+        status = cache_store.get(status_key)
+
+        if status:
+            return cls.Status(status)
+
+        is_up = False
+        try:
+            is_up = func()
+        except Exception:
+            ...
+
+        if is_up:
+            cache_store.set(
+                status_key, cls.Status.CLOSED, ex=cls.STATUS_CACHE_CLOSED_TTL
+            )
+            return cls.Status.CLOSED
+
+        cache_store.set(
+            status_key, cls.Status.OPEN, ex=cls.STATUS_CACHE_OPEN_TTL
+        )
+        return cls.Status.OPEN

--- a/app/services/circuit_breaker.py
+++ b/app/services/circuit_breaker.py
@@ -12,9 +12,9 @@ class CircuitBreaker:
         CLOSED = "CLOSED"
 
     @classmethod
-    def protected_call(cls, func, key):
-        num_failures_key = f"{key}:num_failures"
-        status_key = f"{key}:status"
+    def protected_call(cls, func, cache_key: str, accepted_exceptions: tuple):
+        num_failures_key = f"{cache_key}:num_failures"
+        status_key = f"{cache_key}:status"
 
         status = cache_store.get(status_key)
         if status == cls.Status.OPEN:
@@ -22,7 +22,7 @@ class CircuitBreaker:
 
         try:
             return func()
-        except (KeyError, ValueError) as e:
+        except accepted_exceptions as e:
             raise e
         except Exception as e:
             num_failures = cache_store.incr(num_failures_key)
@@ -35,8 +35,8 @@ class CircuitBreaker:
             raise e
 
     @classmethod
-    def get_status(cls, func, key):
-        status_key = f"{key}:status"
+    def get_status(cls, func, cache_key: str):
+        status_key = f"{cache_key}:status"
         status = cache_store.get(status_key)
 
         if status:

--- a/app/services/circuit_breaker.py
+++ b/app/services/circuit_breaker.py
@@ -21,7 +21,11 @@ class CircuitBreaker:
             raise ValueError("Too many failures! Please try again later.")
 
         try:
-            return func()
+            response = func()
+            cache_store.set(
+                status_key, cls.Status.CLOSED, ex=cls.STATUS_CACHE_CLOSED_TTL
+            )
+            return response
         except accepted_exceptions as e:
             raise e
         except Exception as e:

--- a/app/services/circuit_breaker.py
+++ b/app/services/circuit_breaker.py
@@ -22,7 +22,7 @@ class CircuitBreaker:
         Params:
             func: function to be called
             cache_key: key to be used in the cache store
-            accepted_exceptions: exceptions that are not considereds failures
+            accepted_exceptions: exceptions that are not considered failures
 
         Raises:
             ValueError: if within the last STATUS_CACHE_OPEN_TTL seconds,
@@ -55,13 +55,13 @@ class CircuitBreaker:
             raise e
 
     @classmethod
-    def get_status(cls, func, cache_key: str):
+    def get_status(cls, checkhealth_func, cache_key: str):
         """Get the status of the cache_key.
         If the key is not in the cache, performs the function call.
         Otherwise, returns the cached value.
 
         Params:
-            func: function to be called. This function only returns a boolean.
+            checkhealth_func: function to be called. Only returns a boolean.
             cache_key: key to be used in the cache store
 
         Returns: Status of the cache_key.
@@ -75,7 +75,7 @@ class CircuitBreaker:
 
         is_up = False
         try:
-            is_up = func()
+            is_up = checkhealth_func()
         except Exception:
             ...
 

--- a/app/services/circuit_breaker.py
+++ b/app/services/circuit_breaker.py
@@ -1,5 +1,8 @@
+import logging
 from enum import Enum
 from app.services.cache import cache_store
+
+log = logging.getLogger(__name__)
 
 
 class CircuitBreaker:
@@ -76,8 +79,8 @@ class CircuitBreaker:
         is_up = False
         try:
             is_up = checkhealth_func()
-        except Exception:
-            ...
+        except Exception as e:
+            log.error(e)
 
         if is_up:
             cache_store.set(

--- a/app/services/guidance_wrapper.py
+++ b/app/services/guidance_wrapper.py
@@ -8,7 +8,7 @@ class GuidanceWrapper:
     """A wrapper service to all guidance package's methods."""
 
     def __init__(
-        self, model: LLMModel, handlebars: str, parameters=None
+        self, model: LLMModel, handlebars="", parameters=None
     ) -> None:
         if parameters is None:
             parameters = {}
@@ -37,6 +37,26 @@ class GuidanceWrapper:
             raise ValueError("The handlebars do not generate 'response'")
 
         return Content(type=ContentType.TEXT, textContent=result["response"])
+
+    def is_up(self) -> bool:
+        """Check if the chosen LLM model is up.
+
+        Returns:
+            True if the model is up, False otherwise.
+        """
+
+        handlebars = """
+        {{#user~}}Say 1{{~/user}}
+        {{#assistant~}}
+            {{gen 'response' temperature=0.0 max_tokens=1}}
+        {{~/assistant}}
+        """
+        content = (
+            GuidanceWrapper(model=self.model, handlebars=handlebars)
+            .query()
+            .text_content
+        )
+        return content == "1"
 
     def _get_llm(self):
         llm_credentials = settings.pyris.llm[self.model.value]

--- a/app/services/guidance_wrapper.py
+++ b/app/services/guidance_wrapper.py
@@ -7,6 +7,9 @@ from app.models.dtos import Content, ContentType, LLMModel
 class GuidanceWrapper:
     """A wrapper service to all guidance package's methods."""
 
+    def __new__(cls, *_, **__):
+        return super(GuidanceWrapper, cls).__new__(cls)
+
     def __init__(
         self, model: LLMModel, handlebars="", parameters=None
     ) -> None:

--- a/app/services/guidance_wrapper.py
+++ b/app/services/guidance_wrapper.py
@@ -48,6 +48,7 @@ class GuidanceWrapper:
             True if the model is up, False otherwise.
         """
 
+        guidance.llms.OpenAI.cache.clear()
         handlebars = """
         {{#user~}}Say 1{{~/user}}
         {{#assistant~}}

--- a/app/services/hazelcast_client.py
+++ b/app/services/hazelcast_client.py
@@ -1,0 +1,9 @@
+import hazelcast
+from app.config import settings
+
+hazelcast_client = hazelcast.HazelcastClient(
+    cluster_members=[
+        f"{settings.pyris.cache.hazelcast.host}:\
+        {settings.pyris.cache.hazelcast.port}"
+    ],
+)

--- a/application-docker.test.yml
+++ b/application-docker.test.yml
@@ -1,0 +1,21 @@
+pyris:
+  api_key: secret
+  redis:
+    host: cache
+    port: 6379
+  llm:
+    GPT35_TURBO:
+      model:
+      token:
+      api_base:
+      api_type:
+      api_version:
+      deployment_id:
+    GPT35_TURBO_16K_0613:
+      model:
+      token:
+      chat_mode:
+    GPT35_TURBO_0613:
+      model:
+      token:
+      chat_mode:

--- a/application-docker.test.yml
+++ b/application-docker.test.yml
@@ -1,5 +1,9 @@
 pyris:
   api_key: secret
+  cache:
+    hazelcast:
+      host: cache
+      port: 5701
   llm:
     GPT35_TURBO:
       model:

--- a/application-docker.test.yml
+++ b/application-docker.test.yml
@@ -1,5 +1,4 @@
 pyris:
-  api_key: secret
   cache:
     hazelcast:
       host: cache

--- a/application-docker.test.yml
+++ b/application-docker.test.yml
@@ -1,8 +1,5 @@
 pyris:
   api_key: secret
-  redis:
-    host: cache
-    port: 6379
   llm:
     GPT35_TURBO:
       model:

--- a/application.example.yml
+++ b/application.example.yml
@@ -1,8 +1,5 @@
 pyris:
   api_key: secret
-  redis:
-    host: localhost
-    port: 6379
   llm:
     GPT35_TURBO:
       model:

--- a/application.example.yml
+++ b/application.example.yml
@@ -1,5 +1,9 @@
 pyris:
   api_key: secret
+  cache:
+    hazelcast:
+      host: localhost
+      port: 5701
   llm:
     GPT35_TURBO:
       model:

--- a/application.example.yml
+++ b/application.example.yml
@@ -1,5 +1,8 @@
 pyris:
   api_key: secret
+  redis:
+    host: localhost
+    port: 6379
   llm:
     GPT35_TURBO:
       model:

--- a/application.test.yml
+++ b/application.test.yml
@@ -1,8 +1,5 @@
 pyris:
   api_key: secret
-  redis:
-    host: localhost
-    port: 6379
   llm:
     GPT35_TURBO:
       model:

--- a/application.test.yml
+++ b/application.test.yml
@@ -1,5 +1,8 @@
 pyris:
   api_key: secret
+  redis:
+    host: localhost
+    port: 9736
   llm:
     GPT35_TURBO:
       model:

--- a/application.test.yml
+++ b/application.test.yml
@@ -1,5 +1,9 @@
 pyris:
   api_key: secret
+  cache:
+    hazelcast:
+      host: localhost
+      port: 5701
   llm:
     GPT35_TURBO:
       model:

--- a/application.test.yml
+++ b/application.test.yml
@@ -1,5 +1,4 @@
 pyris:
-  api_key: secret
   cache:
     hazelcast:
       host: localhost

--- a/application.test.yml
+++ b/application.test.yml
@@ -2,7 +2,7 @@ pyris:
   api_key: secret
   redis:
     host: localhost
-    port: 9736
+    port: 6379
   llm:
     GPT35_TURBO:
       model:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       dockerfile: Dockerfile.development
     environment:
       - DOCKER=1
+    depends_on:
+      - cache
     ports:
       - "8000:8000"
     volumes:
@@ -17,6 +19,14 @@ services:
       - pyris
     stdin_open: true
     tty: true
+
+  cache:
+    container_name: pyris-cache
+    image: hazelcast/hazelcast:5.3.1
+    networks:
+      - pyris
+    ports:
+      - '5701:5701'
 
 networks:
   pyris:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.development
+    environment:
+      - DOCKER=1
     depends_on:
       - cache
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.development
+    depends_on:
+      - cache
     ports:
       - "8000:8000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,5 +13,12 @@ services:
     networks:
       - pyris
 
+  cache:
+    image: redis
+    networks:
+      - pyris
+    ports:
+      - '6379:6379'
+
 networks:
   pyris:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       dockerfile: Dockerfile.development
     environment:
       - DOCKER=1
-    depends_on:
-      - cache
     ports:
       - "8000:8000"
     volumes:
@@ -19,14 +17,6 @@ services:
       - pyris
     stdin_open: true
     tty: true
-
-  cache:
-    container_name: pyris-cache
-    image: redis
-    networks:
-      - pyris
-    ports:
-      - '6379:6379'
 
 networks:
   pyris:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.9"
 
 services:
   server:
+    container_name: pyris-server
     build:
       context: .
       dockerfile: Dockerfile.development
@@ -16,8 +17,11 @@ services:
       - .:/app
     networks:
       - pyris
+    stdin_open: true
+    tty: true
 
   cache:
+    container_name: pyris-cache
     image: redis
     networks:
       - pyris

--- a/docker/pyris-production.yml
+++ b/docker/pyris-production.yml
@@ -20,6 +20,11 @@ services:
     networks:
       - pyris
 
+  cache:
+    image: hazelcast/hazelcast:5.3.1
+    networks:
+      - pyris
+
   nginx:
     extends:
       file: ./nginx.yml

--- a/poetry.lock
+++ b/poetry.lock
@@ -684,6 +684,104 @@ files = [
 ]
 
 [[package]]
+name = "hiredis"
+version = "2.2.3"
+description = "Python wrapper for hiredis"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "hiredis-2.2.3-cp310-cp310-macosx_10_12_universal2.whl", hash = "sha256:9a1a80a8fa767f2fdc3870316a54b84fe9fc09fa6ab6a2686783de6a228a4604"},
+    {file = "hiredis-2.2.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3f006c28c885deb99b670a5a66f367a175ab8955b0374029bad7111f5357dcd4"},
+    {file = "hiredis-2.2.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ffaf841546905d90ff189de7397aa56413b1ce5e54547f17a98f0ebf3a3b0a3b"},
+    {file = "hiredis-2.2.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cadb0ac7ba3babfd804e425946bec9717b320564a1390f163a54af9365a720a"},
+    {file = "hiredis-2.2.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:33bc4721632ef9708fa44e5df0066053fccc8e65410a2c48573192517a533b48"},
+    {file = "hiredis-2.2.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:227c5b4bcb60f89008c275d596e4a7b6625a6b3c827b8a66ae582eace7051f71"},
+    {file = "hiredis-2.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61995eb826009d99ed8590747bc0da683a5f4fbb4faa8788166bf3810845cd5c"},
+    {file = "hiredis-2.2.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f969edc851efe23010e0f53a64269f2629a9364135e9ec81c842e8b2277d0c1"},
+    {file = "hiredis-2.2.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d27e560eefb57914d742a837f1da98d3b29cb22eff013c8023b7cf52ae6e051d"},
+    {file = "hiredis-2.2.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3759f4789ae1913b7df278dfc9e8749205b7a106f888cd2903d19461e24a7697"},
+    {file = "hiredis-2.2.3-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:c6cb613148422c523945cdb8b6bed617856f2602fd8750e33773ede2616e55d5"},
+    {file = "hiredis-2.2.3-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:1d274d5c511dfc03f83f997d3238eaa9b6ee3f982640979f509373cced891e98"},
+    {file = "hiredis-2.2.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3b7fe075e91b9d9cff40eba4fb6a8eff74964d3979a39be9a9ef58b1b4cb3604"},
+    {file = "hiredis-2.2.3-cp310-cp310-win32.whl", hash = "sha256:77924b0d32fd1f493d3df15d9609ddf9d94c31a364022a6bf6b525ce9da75bea"},
+    {file = "hiredis-2.2.3-cp310-cp310-win_amd64.whl", hash = "sha256:dcb0569dd5bfe6004658cd0f229efa699a3169dcb4f77bd72e188adda302063d"},
+    {file = "hiredis-2.2.3-cp311-cp311-macosx_10_12_universal2.whl", hash = "sha256:d115790f18daa99b5c11a506e48923b630ef712e9e4b40482af942c3d40638b8"},
+    {file = "hiredis-2.2.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c3b8be557e08b234774925622e196f0ee36fe4eab66cd19df934d3efd8f3743"},
+    {file = "hiredis-2.2.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3f5446068197b35a11ccc697720c41879c8657e2e761aaa8311783aac84cef20"},
+    {file = "hiredis-2.2.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa17a3b22b3726d54d7af20394f65d4a1735a842a4e0f557dc67a90f6965c4bc"},
+    {file = "hiredis-2.2.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7df645b6b7800e8b748c217fbd6a4ca8361bcb9a1ae6206cc02377833ec8a1aa"},
+    {file = "hiredis-2.2.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2fb9300959a0048138791f3d68359d61a788574ec9556bddf1fec07f2dbc5320"},
+    {file = "hiredis-2.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d7e459fe7313925f395148d36d9b7f4f8dac65be06e45d7af356b187cef65fc"},
+    {file = "hiredis-2.2.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8eceffca3941775b646cd585cd19b275d382de43cc3327d22f7c75d7b003d481"},
+    {file = "hiredis-2.2.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b17baf702c6e5b4bb66e1281a3efbb1d749c9d06cdb92b665ad81e03118f78fc"},
+    {file = "hiredis-2.2.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4e43e2b5acaad09cf48c032f7e4926392bb3a3f01854416cf6d82ebff94d5467"},
+    {file = "hiredis-2.2.3-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:a7205497d7276a81fe92951a29616ef96562ed2f91a02066f72b6f93cb34b40e"},
+    {file = "hiredis-2.2.3-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:126623b03c31cb6ac3e0d138feb6fcc36dd43dd34fc7da7b7a0c38b5d75bc896"},
+    {file = "hiredis-2.2.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:071c5814b850574036506a8118034f97c3cbf2fe9947ff45a27b07a48da56240"},
+    {file = "hiredis-2.2.3-cp311-cp311-win32.whl", hash = "sha256:d1be9e30e675f5bc1cb534633324578f6f0944a1bcffe53242cf632f554f83b6"},
+    {file = "hiredis-2.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:b9a7c987e161e3c58f992c63b7e26fea7fe0777f3b975799d23d65bbb8cb5899"},
+    {file = "hiredis-2.2.3-cp37-cp37m-macosx_10_12_x86_64.whl", hash = "sha256:f2dcb8389fa3d453927b1299f46bdb38473c293c8269d5c777d33ea0e526b610"},
+    {file = "hiredis-2.2.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a2df98f5e071320c7d84e8bd07c0542acdd0a7519307fc31774d60e4b842ec4f"},
+    {file = "hiredis-2.2.3-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:61a72e4a523cdfc521762137559c08dfa360a3caef63620be58c699d1717dac1"},
+    {file = "hiredis-2.2.3-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c9b9e5bde7030cae83aa900b5bd660decc65afd2db8c400f3c568c815a47ca2a"},
+    {file = "hiredis-2.2.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd2614f17e261f72efc2f19f5e5ff2ee19e2296570c0dcf33409e22be30710de"},
+    {file = "hiredis-2.2.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:46525fbd84523cac75af5bf524bc74aaac848beaf31b142d2df8a787d9b4bbc4"},
+    {file = "hiredis-2.2.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d1a4ce40ba11da9382c14da31f4f9e88c18f7d294f523decd0fadfb81f51ad18"},
+    {file = "hiredis-2.2.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:5cda592405bbd29d53942e0389dc3fa77b49c362640210d7e94a10c14a677d4d"},
+    {file = "hiredis-2.2.3-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:5e6674a017629284ef373b50496d9fb1a89b85a20a7fa100ecd109484ec748e5"},
+    {file = "hiredis-2.2.3-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:e62ec131816c6120eff40dffe43424e140264a15fa4ab88c301bd6a595913af3"},
+    {file = "hiredis-2.2.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:17e938d9d3ee92e1adbff361706f1c36cc60eeb3e3eeca7a3a353eae344f4c91"},
+    {file = "hiredis-2.2.3-cp37-cp37m-win32.whl", hash = "sha256:95d2305fd2a7b179cacb48b10f618872fc565c175f9f62b854e8d1acac3e8a9e"},
+    {file = "hiredis-2.2.3-cp37-cp37m-win_amd64.whl", hash = "sha256:8f9dbe12f011a9b784f58faecc171d22465bb532c310bd588d769ba79a59ef5a"},
+    {file = "hiredis-2.2.3-cp38-cp38-macosx_10_12_universal2.whl", hash = "sha256:5a4bcef114fc071d5f52c386c47f35aae0a5b43673197b9288a15b584da8fa3a"},
+    {file = "hiredis-2.2.3-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:232d0a70519865741ba56e1dfefd160a580ae78c30a1517bad47b3cf95a3bc7d"},
+    {file = "hiredis-2.2.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9076ce8429785c85f824650735791738de7143f61f43ae9ed83e163c0ca0fa44"},
+    {file = "hiredis-2.2.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec58fb7c2062f835595c12f0f02dcda76d0eb0831423cc191d1e18c9276648de"},
+    {file = "hiredis-2.2.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7f2b34a6444b8f9c1e9f84bd2c639388e5d14f128afd14a869dfb3d9af893aa2"},
+    {file = "hiredis-2.2.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:818dfd310aa1020a13cd08ee48e116dd8c3bb2e23b8161f8ac4df587dd5093d7"},
+    {file = "hiredis-2.2.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96d9ea6c8d4cbdeee2e0d43379ce2881e4af0454b00570677c59f33f2531cd38"},
+    {file = "hiredis-2.2.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f1eadbcd3de55ac42310ff82550d3302cb4efcd4e17d76646a17b6e7004bb42b"},
+    {file = "hiredis-2.2.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:477c34c4489666dc73cb5e89dafe2617c3e13da1298917f73d55aac4696bd793"},
+    {file = "hiredis-2.2.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:14824e457e4f5cda685c3345d125da13949bcf3bb1c88eb5d248c8d2c3dee08f"},
+    {file = "hiredis-2.2.3-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:9cd32326dfa6ce87edf754153b0105aca64486bebe93b9600ccff74fa0b224df"},
+    {file = "hiredis-2.2.3-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:51341e70b467004dcbec3a6ce8c478d2d6241e0f6b01e4c56764afd5022e1e9d"},
+    {file = "hiredis-2.2.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2443659c76b226267e2a04dbbb21bc2a3f91aa53bdc0c22964632753ae43a247"},
+    {file = "hiredis-2.2.3-cp38-cp38-win32.whl", hash = "sha256:4e3e3e31423f888d396b1fc1f936936e52af868ac1ec17dd15e3eeba9dd4de24"},
+    {file = "hiredis-2.2.3-cp38-cp38-win_amd64.whl", hash = "sha256:20f509e3a1a20d6e5f5794fc37ceb21f70f409101fcfe7a8bde783894d51b369"},
+    {file = "hiredis-2.2.3-cp39-cp39-macosx_10_12_universal2.whl", hash = "sha256:d20891e3f33803b26d54c77fd5745878497091e33f4bbbdd454cf6e71aee8890"},
+    {file = "hiredis-2.2.3-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:50171f985e17970f87d5a29e16603d1e5b03bdbf5c2691a37e6c912942a6b657"},
+    {file = "hiredis-2.2.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9944a2cac25ffe049a7e89f306e11b900640837d1ef38d9be0eaa4a4e2b73a52"},
+    {file = "hiredis-2.2.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a5c8019ff94988d56eb49b15de76fe83f6b42536d76edeb6565dbf7fe14b973"},
+    {file = "hiredis-2.2.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a286ded34eb16501002e3713b3130c987366eee2ba0d58c33c72f27778e31676"},
+    {file = "hiredis-2.2.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4b3e974ad15eb32b1f537730dea70b93a4c3db7b026de3ad2b59da49c6f7454d"},
+    {file = "hiredis-2.2.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:08415ea74c1c29b9d6a4ca3dd0e810dc1af343c1d1d442e15ba133b11ab5be6a"},
+    {file = "hiredis-2.2.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e17d04ea58ab8cf3f2dc52e875db16077c6357846006780086fff3189fb199d"},
+    {file = "hiredis-2.2.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:6ccdcb635dae85b006592f78e32d97f4bc7541cb27829d505f9c7fefcef48298"},
+    {file = "hiredis-2.2.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:69536b821dd1bc78058a6e7541743f8d82bf2d981b91280b14c4daa6cdc7faba"},
+    {file = "hiredis-2.2.3-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:3753df5f873d473f055e1f8837bfad0bd3b277c86f3c9bf058c58f14204cd901"},
+    {file = "hiredis-2.2.3-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:6f88cafe46612b6fa68e6dea49e25bebf160598bba00101caa51cc8c1f18d597"},
+    {file = "hiredis-2.2.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:33ee3ea5cad3a8cb339352cd230b411eb437a2e75d7736c4899acab32056ccdb"},
+    {file = "hiredis-2.2.3-cp39-cp39-win32.whl", hash = "sha256:b4f3d06dc16671b88a13ae85d8ca92534c0b637d59e49f0558d040a691246422"},
+    {file = "hiredis-2.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:4f674e309cd055ee7a48304ceb8cf43265d859faf4d7d01d270ce45e976ae9d3"},
+    {file = "hiredis-2.2.3-pp37-pypy37_pp73-macosx_10_12_x86_64.whl", hash = "sha256:8f280ab4e043b089777b43b4227bdc2035f88da5072ab36588e0ccf77d45d058"},
+    {file = "hiredis-2.2.3-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15c2a551f3b8a26f7940d6ee10b837810201754b8d7e6f6b1391655370882c5a"},
+    {file = "hiredis-2.2.3-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60c4e3c258eafaab21b174b17270a0cc093718d61cdbde8c03f85ec4bf835343"},
+    {file = "hiredis-2.2.3-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc36a9dded458d4e37492fe3e619c6c83caae794d26ad925adbce61d592f8428"},
+    {file = "hiredis-2.2.3-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:4ed68a3b1ccb4313d2a42546fd7e7439ad4745918a48b6c9bcaa61e1e3e42634"},
+    {file = "hiredis-2.2.3-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3bf4b5bae472630c229518e4a814b1b68f10a3d9b00aeaec45f1a330f03a0251"},
+    {file = "hiredis-2.2.3-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33a94d264e6e12a79d9bb8af333b01dc286b9f39c99072ab5fef94ce1f018e17"},
+    {file = "hiredis-2.2.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3fa6811a618653164f918b891a0fa07052bd71a799defa5c44d167cac5557b26"},
+    {file = "hiredis-2.2.3-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:af33f370be90b48bbaf0dab32decbdcc522b1fa95d109020a963282086518a8e"},
+    {file = "hiredis-2.2.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:b9953d87418ac228f508d93898ab572775e4d3b0eeb886a1a7734553bcdaf291"},
+    {file = "hiredis-2.2.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5e7bb4dd524f50b71c20ef5a12bd61da9b463f8894b18a06130942fe31509881"},
+    {file = "hiredis-2.2.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89a258424158eb8b3ed9f65548d68998da334ef155d09488c5637723eb1cd697"},
+    {file = "hiredis-2.2.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f4a65276f6ecdebe75f2a53f578fbc40e8d2860658420d5e0611c56bbf5054c"},
+    {file = "hiredis-2.2.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:334f2738700b20faa04a0d813366fb16ed17287430a6b50584161d5ad31ca6d7"},
+    {file = "hiredis-2.2.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:d194decd9608f11c777946f596f31d5aacad13972a0a87829ae1e6f2d26c1885"},
+    {file = "hiredis-2.2.3.tar.gz", hash = "sha256:e75163773a309e56a9b58165cf5a50e0f84b755f6ff863b2c01a38918fe92daa"},
+]
+
+[[package]]
 name = "httpcore"
 version = "0.17.2"
 description = "A minimal low-level HTTP client."
@@ -1312,6 +1410,25 @@ files = [
 ]
 
 [[package]]
+name = "redis"
+version = "4.5.5"
+description = "Python client for Redis database and key-value store"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "redis-4.5.5-py3-none-any.whl", hash = "sha256:77929bc7f5dab9adf3acba2d3bb7d7658f1e0c2f1cafe7eb36434e751c471119"},
+    {file = "redis-4.5.5.tar.gz", hash = "sha256:dc87a0bdef6c8bfe1ef1e1c40be7034390c2ae02d92dcd0c7ca1729443899880"},
+]
+
+[package.dependencies]
+async-timeout = {version = ">=4.0.2", markers = "python_full_version <= \"3.11.2\""}
+hiredis = {version = ">=1.0.0", optional = true, markers = "extra == \"hiredis\""}
+
+[package.extras]
+hiredis = ["hiredis (>=1.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
+
+[[package]]
 name = "regex"
 version = "2023.6.3"
 description = "Alternative regular expression module, to replace re."
@@ -1685,4 +1802,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "b83563649a2522f40201bf8dc85840d598af963506883d700b744b5c5660bb13"
+content-hash = "166c46e8b5fca2eae85365606e13edddb6580b2d7869754f4c58809d0a218bac"

--- a/poetry.lock
+++ b/poetry.lock
@@ -684,6 +684,20 @@ files = [
 ]
 
 [[package]]
+name = "hazelcast-python-client"
+version = "5.3.0"
+description = "Hazelcast Python Client"
+optional = false
+python-versions = "*"
+files = [
+    {file = "hazelcast-python-client-5.3.0.tar.gz", hash = "sha256:9defd4adf4d25d66ca49383c78d8762960ae6ab96a3e1fecaa729b026542a5fc"},
+    {file = "hazelcast_python_client-5.3.0-py3-none-any.whl", hash = "sha256:effba1748ba57b2dbb1a5aaa912e52ee039ed49f2d20dab7540fe7ac9c72688c"},
+]
+
+[package.extras]
+stats = ["psutil"]
+
+[[package]]
 name = "httpcore"
 version = "0.17.2"
 description = "A minimal low-level HTTP client."
@@ -1685,4 +1699,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "b83563649a2522f40201bf8dc85840d598af963506883d700b744b5c5660bb13"
+content-hash = "e9b1efc973bd3001cecab42718d04a9f043b378647fa5695ba4a26469f237c9c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -684,104 +684,6 @@ files = [
 ]
 
 [[package]]
-name = "hiredis"
-version = "2.2.3"
-description = "Python wrapper for hiredis"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "hiredis-2.2.3-cp310-cp310-macosx_10_12_universal2.whl", hash = "sha256:9a1a80a8fa767f2fdc3870316a54b84fe9fc09fa6ab6a2686783de6a228a4604"},
-    {file = "hiredis-2.2.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3f006c28c885deb99b670a5a66f367a175ab8955b0374029bad7111f5357dcd4"},
-    {file = "hiredis-2.2.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ffaf841546905d90ff189de7397aa56413b1ce5e54547f17a98f0ebf3a3b0a3b"},
-    {file = "hiredis-2.2.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cadb0ac7ba3babfd804e425946bec9717b320564a1390f163a54af9365a720a"},
-    {file = "hiredis-2.2.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:33bc4721632ef9708fa44e5df0066053fccc8e65410a2c48573192517a533b48"},
-    {file = "hiredis-2.2.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:227c5b4bcb60f89008c275d596e4a7b6625a6b3c827b8a66ae582eace7051f71"},
-    {file = "hiredis-2.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61995eb826009d99ed8590747bc0da683a5f4fbb4faa8788166bf3810845cd5c"},
-    {file = "hiredis-2.2.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f969edc851efe23010e0f53a64269f2629a9364135e9ec81c842e8b2277d0c1"},
-    {file = "hiredis-2.2.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d27e560eefb57914d742a837f1da98d3b29cb22eff013c8023b7cf52ae6e051d"},
-    {file = "hiredis-2.2.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3759f4789ae1913b7df278dfc9e8749205b7a106f888cd2903d19461e24a7697"},
-    {file = "hiredis-2.2.3-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:c6cb613148422c523945cdb8b6bed617856f2602fd8750e33773ede2616e55d5"},
-    {file = "hiredis-2.2.3-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:1d274d5c511dfc03f83f997d3238eaa9b6ee3f982640979f509373cced891e98"},
-    {file = "hiredis-2.2.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3b7fe075e91b9d9cff40eba4fb6a8eff74964d3979a39be9a9ef58b1b4cb3604"},
-    {file = "hiredis-2.2.3-cp310-cp310-win32.whl", hash = "sha256:77924b0d32fd1f493d3df15d9609ddf9d94c31a364022a6bf6b525ce9da75bea"},
-    {file = "hiredis-2.2.3-cp310-cp310-win_amd64.whl", hash = "sha256:dcb0569dd5bfe6004658cd0f229efa699a3169dcb4f77bd72e188adda302063d"},
-    {file = "hiredis-2.2.3-cp311-cp311-macosx_10_12_universal2.whl", hash = "sha256:d115790f18daa99b5c11a506e48923b630ef712e9e4b40482af942c3d40638b8"},
-    {file = "hiredis-2.2.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4c3b8be557e08b234774925622e196f0ee36fe4eab66cd19df934d3efd8f3743"},
-    {file = "hiredis-2.2.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3f5446068197b35a11ccc697720c41879c8657e2e761aaa8311783aac84cef20"},
-    {file = "hiredis-2.2.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa17a3b22b3726d54d7af20394f65d4a1735a842a4e0f557dc67a90f6965c4bc"},
-    {file = "hiredis-2.2.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7df645b6b7800e8b748c217fbd6a4ca8361bcb9a1ae6206cc02377833ec8a1aa"},
-    {file = "hiredis-2.2.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2fb9300959a0048138791f3d68359d61a788574ec9556bddf1fec07f2dbc5320"},
-    {file = "hiredis-2.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d7e459fe7313925f395148d36d9b7f4f8dac65be06e45d7af356b187cef65fc"},
-    {file = "hiredis-2.2.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8eceffca3941775b646cd585cd19b275d382de43cc3327d22f7c75d7b003d481"},
-    {file = "hiredis-2.2.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b17baf702c6e5b4bb66e1281a3efbb1d749c9d06cdb92b665ad81e03118f78fc"},
-    {file = "hiredis-2.2.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4e43e2b5acaad09cf48c032f7e4926392bb3a3f01854416cf6d82ebff94d5467"},
-    {file = "hiredis-2.2.3-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:a7205497d7276a81fe92951a29616ef96562ed2f91a02066f72b6f93cb34b40e"},
-    {file = "hiredis-2.2.3-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:126623b03c31cb6ac3e0d138feb6fcc36dd43dd34fc7da7b7a0c38b5d75bc896"},
-    {file = "hiredis-2.2.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:071c5814b850574036506a8118034f97c3cbf2fe9947ff45a27b07a48da56240"},
-    {file = "hiredis-2.2.3-cp311-cp311-win32.whl", hash = "sha256:d1be9e30e675f5bc1cb534633324578f6f0944a1bcffe53242cf632f554f83b6"},
-    {file = "hiredis-2.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:b9a7c987e161e3c58f992c63b7e26fea7fe0777f3b975799d23d65bbb8cb5899"},
-    {file = "hiredis-2.2.3-cp37-cp37m-macosx_10_12_x86_64.whl", hash = "sha256:f2dcb8389fa3d453927b1299f46bdb38473c293c8269d5c777d33ea0e526b610"},
-    {file = "hiredis-2.2.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a2df98f5e071320c7d84e8bd07c0542acdd0a7519307fc31774d60e4b842ec4f"},
-    {file = "hiredis-2.2.3-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:61a72e4a523cdfc521762137559c08dfa360a3caef63620be58c699d1717dac1"},
-    {file = "hiredis-2.2.3-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c9b9e5bde7030cae83aa900b5bd660decc65afd2db8c400f3c568c815a47ca2a"},
-    {file = "hiredis-2.2.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd2614f17e261f72efc2f19f5e5ff2ee19e2296570c0dcf33409e22be30710de"},
-    {file = "hiredis-2.2.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:46525fbd84523cac75af5bf524bc74aaac848beaf31b142d2df8a787d9b4bbc4"},
-    {file = "hiredis-2.2.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d1a4ce40ba11da9382c14da31f4f9e88c18f7d294f523decd0fadfb81f51ad18"},
-    {file = "hiredis-2.2.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:5cda592405bbd29d53942e0389dc3fa77b49c362640210d7e94a10c14a677d4d"},
-    {file = "hiredis-2.2.3-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:5e6674a017629284ef373b50496d9fb1a89b85a20a7fa100ecd109484ec748e5"},
-    {file = "hiredis-2.2.3-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:e62ec131816c6120eff40dffe43424e140264a15fa4ab88c301bd6a595913af3"},
-    {file = "hiredis-2.2.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:17e938d9d3ee92e1adbff361706f1c36cc60eeb3e3eeca7a3a353eae344f4c91"},
-    {file = "hiredis-2.2.3-cp37-cp37m-win32.whl", hash = "sha256:95d2305fd2a7b179cacb48b10f618872fc565c175f9f62b854e8d1acac3e8a9e"},
-    {file = "hiredis-2.2.3-cp37-cp37m-win_amd64.whl", hash = "sha256:8f9dbe12f011a9b784f58faecc171d22465bb532c310bd588d769ba79a59ef5a"},
-    {file = "hiredis-2.2.3-cp38-cp38-macosx_10_12_universal2.whl", hash = "sha256:5a4bcef114fc071d5f52c386c47f35aae0a5b43673197b9288a15b584da8fa3a"},
-    {file = "hiredis-2.2.3-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:232d0a70519865741ba56e1dfefd160a580ae78c30a1517bad47b3cf95a3bc7d"},
-    {file = "hiredis-2.2.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9076ce8429785c85f824650735791738de7143f61f43ae9ed83e163c0ca0fa44"},
-    {file = "hiredis-2.2.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec58fb7c2062f835595c12f0f02dcda76d0eb0831423cc191d1e18c9276648de"},
-    {file = "hiredis-2.2.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7f2b34a6444b8f9c1e9f84bd2c639388e5d14f128afd14a869dfb3d9af893aa2"},
-    {file = "hiredis-2.2.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:818dfd310aa1020a13cd08ee48e116dd8c3bb2e23b8161f8ac4df587dd5093d7"},
-    {file = "hiredis-2.2.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96d9ea6c8d4cbdeee2e0d43379ce2881e4af0454b00570677c59f33f2531cd38"},
-    {file = "hiredis-2.2.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f1eadbcd3de55ac42310ff82550d3302cb4efcd4e17d76646a17b6e7004bb42b"},
-    {file = "hiredis-2.2.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:477c34c4489666dc73cb5e89dafe2617c3e13da1298917f73d55aac4696bd793"},
-    {file = "hiredis-2.2.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:14824e457e4f5cda685c3345d125da13949bcf3bb1c88eb5d248c8d2c3dee08f"},
-    {file = "hiredis-2.2.3-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:9cd32326dfa6ce87edf754153b0105aca64486bebe93b9600ccff74fa0b224df"},
-    {file = "hiredis-2.2.3-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:51341e70b467004dcbec3a6ce8c478d2d6241e0f6b01e4c56764afd5022e1e9d"},
-    {file = "hiredis-2.2.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2443659c76b226267e2a04dbbb21bc2a3f91aa53bdc0c22964632753ae43a247"},
-    {file = "hiredis-2.2.3-cp38-cp38-win32.whl", hash = "sha256:4e3e3e31423f888d396b1fc1f936936e52af868ac1ec17dd15e3eeba9dd4de24"},
-    {file = "hiredis-2.2.3-cp38-cp38-win_amd64.whl", hash = "sha256:20f509e3a1a20d6e5f5794fc37ceb21f70f409101fcfe7a8bde783894d51b369"},
-    {file = "hiredis-2.2.3-cp39-cp39-macosx_10_12_universal2.whl", hash = "sha256:d20891e3f33803b26d54c77fd5745878497091e33f4bbbdd454cf6e71aee8890"},
-    {file = "hiredis-2.2.3-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:50171f985e17970f87d5a29e16603d1e5b03bdbf5c2691a37e6c912942a6b657"},
-    {file = "hiredis-2.2.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9944a2cac25ffe049a7e89f306e11b900640837d1ef38d9be0eaa4a4e2b73a52"},
-    {file = "hiredis-2.2.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a5c8019ff94988d56eb49b15de76fe83f6b42536d76edeb6565dbf7fe14b973"},
-    {file = "hiredis-2.2.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a286ded34eb16501002e3713b3130c987366eee2ba0d58c33c72f27778e31676"},
-    {file = "hiredis-2.2.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4b3e974ad15eb32b1f537730dea70b93a4c3db7b026de3ad2b59da49c6f7454d"},
-    {file = "hiredis-2.2.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:08415ea74c1c29b9d6a4ca3dd0e810dc1af343c1d1d442e15ba133b11ab5be6a"},
-    {file = "hiredis-2.2.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e17d04ea58ab8cf3f2dc52e875db16077c6357846006780086fff3189fb199d"},
-    {file = "hiredis-2.2.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:6ccdcb635dae85b006592f78e32d97f4bc7541cb27829d505f9c7fefcef48298"},
-    {file = "hiredis-2.2.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:69536b821dd1bc78058a6e7541743f8d82bf2d981b91280b14c4daa6cdc7faba"},
-    {file = "hiredis-2.2.3-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:3753df5f873d473f055e1f8837bfad0bd3b277c86f3c9bf058c58f14204cd901"},
-    {file = "hiredis-2.2.3-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:6f88cafe46612b6fa68e6dea49e25bebf160598bba00101caa51cc8c1f18d597"},
-    {file = "hiredis-2.2.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:33ee3ea5cad3a8cb339352cd230b411eb437a2e75d7736c4899acab32056ccdb"},
-    {file = "hiredis-2.2.3-cp39-cp39-win32.whl", hash = "sha256:b4f3d06dc16671b88a13ae85d8ca92534c0b637d59e49f0558d040a691246422"},
-    {file = "hiredis-2.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:4f674e309cd055ee7a48304ceb8cf43265d859faf4d7d01d270ce45e976ae9d3"},
-    {file = "hiredis-2.2.3-pp37-pypy37_pp73-macosx_10_12_x86_64.whl", hash = "sha256:8f280ab4e043b089777b43b4227bdc2035f88da5072ab36588e0ccf77d45d058"},
-    {file = "hiredis-2.2.3-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15c2a551f3b8a26f7940d6ee10b837810201754b8d7e6f6b1391655370882c5a"},
-    {file = "hiredis-2.2.3-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60c4e3c258eafaab21b174b17270a0cc093718d61cdbde8c03f85ec4bf835343"},
-    {file = "hiredis-2.2.3-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc36a9dded458d4e37492fe3e619c6c83caae794d26ad925adbce61d592f8428"},
-    {file = "hiredis-2.2.3-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:4ed68a3b1ccb4313d2a42546fd7e7439ad4745918a48b6c9bcaa61e1e3e42634"},
-    {file = "hiredis-2.2.3-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3bf4b5bae472630c229518e4a814b1b68f10a3d9b00aeaec45f1a330f03a0251"},
-    {file = "hiredis-2.2.3-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33a94d264e6e12a79d9bb8af333b01dc286b9f39c99072ab5fef94ce1f018e17"},
-    {file = "hiredis-2.2.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3fa6811a618653164f918b891a0fa07052bd71a799defa5c44d167cac5557b26"},
-    {file = "hiredis-2.2.3-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:af33f370be90b48bbaf0dab32decbdcc522b1fa95d109020a963282086518a8e"},
-    {file = "hiredis-2.2.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:b9953d87418ac228f508d93898ab572775e4d3b0eeb886a1a7734553bcdaf291"},
-    {file = "hiredis-2.2.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5e7bb4dd524f50b71c20ef5a12bd61da9b463f8894b18a06130942fe31509881"},
-    {file = "hiredis-2.2.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89a258424158eb8b3ed9f65548d68998da334ef155d09488c5637723eb1cd697"},
-    {file = "hiredis-2.2.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f4a65276f6ecdebe75f2a53f578fbc40e8d2860658420d5e0611c56bbf5054c"},
-    {file = "hiredis-2.2.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:334f2738700b20faa04a0d813366fb16ed17287430a6b50584161d5ad31ca6d7"},
-    {file = "hiredis-2.2.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:d194decd9608f11c777946f596f31d5aacad13972a0a87829ae1e6f2d26c1885"},
-    {file = "hiredis-2.2.3.tar.gz", hash = "sha256:e75163773a309e56a9b58165cf5a50e0f84b755f6ff863b2c01a38918fe92daa"},
-]
-
-[[package]]
 name = "httpcore"
 version = "0.17.2"
 description = "A minimal low-level HTTP client."
@@ -1410,25 +1312,6 @@ files = [
 ]
 
 [[package]]
-name = "redis"
-version = "4.5.5"
-description = "Python client for Redis database and key-value store"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "redis-4.5.5-py3-none-any.whl", hash = "sha256:77929bc7f5dab9adf3acba2d3bb7d7658f1e0c2f1cafe7eb36434e751c471119"},
-    {file = "redis-4.5.5.tar.gz", hash = "sha256:dc87a0bdef6c8bfe1ef1e1c40be7034390c2ae02d92dcd0c7ca1729443899880"},
-]
-
-[package.dependencies]
-async-timeout = {version = ">=4.0.2", markers = "python_full_version <= \"3.11.2\""}
-hiredis = {version = ">=1.0.0", optional = true, markers = "extra == \"hiredis\""}
-
-[package.extras]
-hiredis = ["hiredis (>=1.0.0)"]
-ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
-
-[[package]]
 name = "regex"
 version = "2023.6.3"
 description = "Alternative regular expression module, to replace re."
@@ -1802,4 +1685,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "166c46e8b5fca2eae85365606e13edddb6580b2d7869754f4c58809d0a218bac"
+content-hash = "b83563649a2522f40201bf8dc85840d598af963506883d700b744b5c5660bb13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ black = "^23.3.0"
 flake8 = "^6.0.0"
 pyaml-env = "^1.2.1"
 gunicorn = "^20.1.0"
+redis = {extras = ["hiredis"], version = "^4.5.5"}
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ black = "^23.3.0"
 flake8 = "^6.0.0"
 pyaml-env = "^1.2.1"
 gunicorn = "^20.1.0"
+hazelcast-python-client = "^5.3.0"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ black = "^23.3.0"
 flake8 = "^6.0.0"
 pyaml-env = "^1.2.1"
 gunicorn = "^20.1.0"
-redis = {extras = ["hiredis"], version = "^4.5.5"}
 
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,19 @@
 import pytest
 from fastapi.testclient import TestClient
 from app.main import app
+from app.services.cache import cache_store
+
+
+@pytest.fixture(autouse=True)
+def clean_cache_store():
+    cache_store.flushdb()
+    yield
+    cache_store.flushdb()
+
+
+@pytest.fixture(scope="session")
+def test_cache_store():
+    return cache_store
 
 
 @pytest.fixture(scope="session")

--- a/tests/routes/health_test.py
+++ b/tests/routes/health_test.py
@@ -1,0 +1,50 @@
+from app.models.dtos import LLMModel
+
+
+def test_checkhealth(test_client, headers, mocker):
+    objA = mocker.Mock()
+    objB = mocker.Mock()
+    objC = mocker.Mock()
+
+    def side_effect_func(*_, **kwargs):
+        if kwargs["model"] == LLMModel.GPT35_TURBO:
+            return objA
+        elif kwargs["model"] == LLMModel.GPT35_TURBO_16K_0613:
+            return objB
+        elif kwargs["model"] == LLMModel.GPT35_TURBO_0613:
+            return objC
+
+    mocker.patch(
+        "app.services.guidance_wrapper.GuidanceWrapper.__new__",
+        side_effect=side_effect_func,
+    )
+    mocker.patch.object(objA, "is_up", return_value=True)
+    mocker.patch.object(objB, "is_up", return_value=False)
+    mocker.patch.object(objC, "is_up", return_value=True)
+
+    response = test_client.get("/api/v1/health", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == [
+        {"model": "GPT35_TURBO", "status": "UP"},
+        {"model": "GPT35_TURBO_16K_0613", "status": "DOWN"},
+        {"model": "GPT35_TURBO_0613", "status": "UP"},
+    ]
+
+    # Assert the second call is cached
+    test_client.get("/api/v1/health", headers=headers)
+    objA.is_up.assert_called_once()
+    objB.is_up.assert_called_once()
+    objC.is_up.assert_called_once()
+
+
+def test_checkhealth_with_wrong_api_key(test_client):
+    headers = {"Authorization": "wrong api key"}
+    response = test_client.get("/api/v1/health", headers=headers)
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Permission denied"
+
+
+def test_checkhealth_without_authorization_header(test_client):
+    response = test_client.get("/api/v1/health")
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Requires authentication"

--- a/tests/routes/messages_test.py
+++ b/tests/routes/messages_test.py
@@ -147,6 +147,8 @@ def test_send_message_fail_three_times(
 
     # Restrict access
     response = test_client.post("/api/v1/messages", headers=headers, json=body)
+    assert test_cache_store.get("LLMModel.GPT35_TURBO:status") == "OPEN"
+    assert test_cache_store.get("LLMModel.GPT35_TURBO:num_failures") == 3
     assert response.status_code == 500
     assert response.json() == {
         "detail": {

--- a/tests/routes/messages_test.py
+++ b/tests/routes/messages_test.py
@@ -151,7 +151,9 @@ def test_send_message_without_authorization_header(test_client):
 def test_send_message_fail_three_times(
     test_client, mocker, headers, test_cache_store
 ):
-    mocker.patch.object(GuidanceWrapper, "query", side_effect=Exception)
+    mocker.patch.object(
+        GuidanceWrapper, "query", side_effect=Exception("some error")
+    )
     body = {
         "template": {
             "id": 123,
@@ -184,3 +186,9 @@ def test_send_message_fail_three_times(
     test_cache_store.delete("GPT35_TURBO:num_failures")
     response = test_client.post("/api/v1/messages", headers=headers, json=body)
     assert response.status_code == 500
+    assert response.json() == {
+        "detail": {
+            "errorMessage": "some error",
+            "type": "other",
+        }
+    }

--- a/tests/services/cache_test.py
+++ b/tests/services/cache_test.py
@@ -77,12 +77,14 @@ class TestInMemoryCacheStore:
         assert "test_key" not in test_cache_store._cache
 
     def test_incr_a_non_existing_key(self, test_cache_store):
-        test_cache_store.incr("test_key")
+        response = test_cache_store.incr("test_key")
+        assert response == 1
         assert test_cache_store.get("test_key") == 1
 
     def test_incr_a_existing_key(self, test_cache_store):
         test_cache_store.set("test_key", 1)
-        test_cache_store.incr("test_key")
+        response = test_cache_store.incr("test_key")
+        assert response == 2
         assert test_cache_store.get("test_key") == 2
 
     def test_incr_a_existing_key_not_a_number(self, test_cache_store):

--- a/tests/services/cache_test.py
+++ b/tests/services/cache_test.py
@@ -7,21 +7,21 @@ class TestInMemoryCacheStore:
     def test_set_and_get(self, test_cache_store):
         test_cache_store.set("test_key", "test_value")
         assert test_cache_store.get("test_key") == "test_value"
-        assert test_cache_store._cache["test_key"].ttl is None
+        assert test_cache_store._cache["test_key"].expired_at is None
 
     @freeze_time("2023-06-16 03:21:34 +02:00")
     def test_set_and_get_an_existing_key(self, test_cache_store):
         test_cache_store.set("test_key", "test_value", ex=30)
         assert test_cache_store.get("test_key") == "test_value"
-        assert test_cache_store._cache["test_key"].ttl == datetime(
+        assert test_cache_store._cache["test_key"].expired_at == datetime(
             year=2023, month=6, day=16, hour=1, minute=22, second=4
         )
 
         test_cache_store.set("test_key", "test_value2")
         assert test_cache_store.get("test_key") == "test_value2"
-        assert test_cache_store._cache["test_key"].ttl is None
+        assert test_cache_store._cache["test_key"].expired_at is None
 
-    def test_set_and_get_before_ttl(self, test_cache_store):
+    def test_set_and_get_before_expired_time(self, test_cache_store):
         initial_datetime = datetime(
             year=1, month=1, day=1, hour=15, minute=2, second=3
         )
@@ -32,18 +32,18 @@ class TestInMemoryCacheStore:
         with freeze_time(initial_datetime) as frozen_datetime:
             test_cache_store.set("test_key", "test_value", ex=40)
             assert test_cache_store.get("test_key") == "test_value"
-            assert test_cache_store._cache["test_key"].ttl == datetime(
+            assert test_cache_store._cache["test_key"].expired_at == datetime(
                 year=1, month=1, day=1, hour=15, minute=2, second=43
             )
 
             frozen_datetime.move_to(other_datetime)
 
             assert test_cache_store.get("test_key") == "test_value"
-            assert test_cache_store._cache["test_key"].ttl == datetime(
+            assert test_cache_store._cache["test_key"].expired_at == datetime(
                 year=1, month=1, day=1, hour=15, minute=2, second=43
             )
 
-    def test_set_and_get_after_ttl(self, test_cache_store):
+    def test_set_and_get_after_expired_time(self, test_cache_store):
         initial_datetime = datetime(
             year=1, month=1, day=1, hour=15, minute=2, second=3
         )
@@ -54,7 +54,7 @@ class TestInMemoryCacheStore:
         with freeze_time(initial_datetime) as frozen_datetime:
             test_cache_store.set("test_key", "test_value", ex=30)
             assert test_cache_store.get("test_key") == "test_value"
-            assert test_cache_store._cache["test_key"].ttl == datetime(
+            assert test_cache_store._cache["test_key"].expired_at == datetime(
                 year=1, month=1, day=1, hour=15, minute=2, second=33
             )
 
@@ -67,7 +67,7 @@ class TestInMemoryCacheStore:
     def test_expire_a_existing_key(self, test_cache_store):
         test_cache_store.set("test_key", "test_value")
         test_cache_store.expire("test_key", 30)
-        assert test_cache_store._cache["test_key"].ttl == datetime(
+        assert test_cache_store._cache["test_key"].expired_at == datetime(
             year=2023, month=6, day=16, hour=1, minute=22, second=4
         )
 

--- a/tests/services/cache_test.py
+++ b/tests/services/cache_test.py
@@ -7,19 +7,19 @@ class TestInMemoryCacheStore:
     def test_set_and_get(self, test_cache_store):
         test_cache_store.set("test_key", "test_value")
         assert test_cache_store.get("test_key") == "test_value"
-        assert test_cache_store.get("test_key:ttl") is None
+        assert test_cache_store._cache["test_key"].ttl is None
 
     @freeze_time("2023-06-16 03:21:34 +02:00")
     def test_set_and_get_an_existing_key(self, test_cache_store):
         test_cache_store.set("test_key", "test_value", ex=30)
         assert test_cache_store.get("test_key") == "test_value"
-        assert test_cache_store.get("test_key:ttl") == datetime(
+        assert test_cache_store._cache["test_key"].ttl == datetime(
             year=2023, month=6, day=16, hour=1, minute=22, second=4
         )
 
         test_cache_store.set("test_key", "test_value2")
         assert test_cache_store.get("test_key") == "test_value2"
-        assert test_cache_store.get("test_key:ttl") is None
+        assert test_cache_store._cache["test_key"].ttl is None
 
     def test_set_and_get_before_ttl(self, test_cache_store):
         initial_datetime = datetime(
@@ -32,14 +32,14 @@ class TestInMemoryCacheStore:
         with freeze_time(initial_datetime) as frozen_datetime:
             test_cache_store.set("test_key", "test_value", ex=40)
             assert test_cache_store.get("test_key") == "test_value"
-            assert test_cache_store.get("test_key:ttl") == datetime(
+            assert test_cache_store._cache["test_key"].ttl == datetime(
                 year=1, month=1, day=1, hour=15, minute=2, second=43
             )
 
             frozen_datetime.move_to(other_datetime)
 
             assert test_cache_store.get("test_key") == "test_value"
-            assert test_cache_store.get("test_key:ttl") == datetime(
+            assert test_cache_store._cache["test_key"].ttl == datetime(
                 year=1, month=1, day=1, hour=15, minute=2, second=43
             )
 
@@ -54,21 +54,27 @@ class TestInMemoryCacheStore:
         with freeze_time(initial_datetime) as frozen_datetime:
             test_cache_store.set("test_key", "test_value", ex=30)
             assert test_cache_store.get("test_key") == "test_value"
-            assert test_cache_store.get("test_key:ttl") == datetime(
+            assert test_cache_store._cache["test_key"].ttl == datetime(
                 year=1, month=1, day=1, hour=15, minute=2, second=33
             )
 
             frozen_datetime.move_to(other_datetime)
 
             assert test_cache_store.get("test_key") is None
-            assert test_cache_store.get("test_key:ttl") is None
+            assert "test_key" not in test_cache_store._cache
 
     @freeze_time("2023-06-16 03:21:34 +02:00")
-    def test_expire(self, test_cache_store):
+    def test_expire_a_existing_key(self, test_cache_store):
+        test_cache_store.set("test_key", "test_value")
         test_cache_store.expire("test_key", 30)
-        assert test_cache_store.get("test_key:ttl") == datetime(
+        assert test_cache_store._cache["test_key"].ttl == datetime(
             year=2023, month=6, day=16, hour=1, minute=22, second=4
         )
+
+    @freeze_time("2023-06-16 03:21:34 +02:00")
+    def test_expire_a_non_existing_key(self, test_cache_store):
+        test_cache_store.expire("test_key", 30)
+        assert "test_key" not in test_cache_store._cache
 
     def test_incr_a_non_existing_key(self, test_cache_store):
         test_cache_store.incr("test_key")
@@ -95,11 +101,11 @@ class TestInMemoryCacheStore:
         test_cache_store.delete("test_key")
 
         assert test_cache_store.get("test_key") is None
-        assert test_cache_store.get("test_key:ttl") is None
+        assert "test_key" not in test_cache_store._cache
 
     def test_delete_a_existing_key(self, test_cache_store):
         test_cache_store.set("test_key", "test_value", ex=1000)
         test_cache_store.delete("test_key")
 
         assert test_cache_store.get("test_key") is None
-        assert test_cache_store.get("test_key:ttl") is None
+        assert "test_key" not in test_cache_store._cache

--- a/tests/services/cache_test.py
+++ b/tests/services/cache_test.py
@@ -1,27 +1,38 @@
 import pytest
 from datetime import datetime
 from freezegun import freeze_time
+from app.services.cache import HazelcastCacheStore, InMemoryCacheStore
+
+
+@pytest.fixture(scope="function")
+def in_memory_cache():
+    return InMemoryCacheStore()
+
+
+@pytest.fixture(scope="function")
+def hazelcast_cache():
+    return HazelcastCacheStore()
 
 
 class TestInMemoryCacheStore:
-    def test_set_and_get(self, test_cache_store):
-        test_cache_store.set("test_key", "test_value")
-        assert test_cache_store.get("test_key") == "test_value"
-        assert test_cache_store._cache["test_key"].expired_at is None
+    def test_set_and_get(self, in_memory_cache):
+        in_memory_cache.set("test_key", "test_value")
+        assert in_memory_cache.get("test_key") == "test_value"
+        assert in_memory_cache._cache["test_key"].expired_at is None
 
     @freeze_time("2023-06-16 03:21:34 +02:00")
-    def test_set_and_get_an_existing_key(self, test_cache_store):
-        test_cache_store.set("test_key", "test_value", ex=30)
-        assert test_cache_store.get("test_key") == "test_value"
-        assert test_cache_store._cache["test_key"].expired_at == datetime(
+    def test_set_and_get_an_existing_key(self, in_memory_cache):
+        in_memory_cache.set("test_key", "test_value", ex=30)
+        assert in_memory_cache.get("test_key") == "test_value"
+        assert in_memory_cache._cache["test_key"].expired_at == datetime(
             year=2023, month=6, day=16, hour=1, minute=22, second=4
         )
 
-        test_cache_store.set("test_key", "test_value2")
-        assert test_cache_store.get("test_key") == "test_value2"
-        assert test_cache_store._cache["test_key"].expired_at is None
+        in_memory_cache.set("test_key", "test_value2")
+        assert in_memory_cache.get("test_key") == "test_value2"
+        assert in_memory_cache._cache["test_key"].expired_at is None
 
-    def test_set_and_get_before_expired_time(self, test_cache_store):
+    def test_set_and_get_before_expired_time(self, in_memory_cache):
         initial_datetime = datetime(
             year=1, month=1, day=1, hour=15, minute=2, second=3
         )
@@ -30,20 +41,20 @@ class TestInMemoryCacheStore:
         )
 
         with freeze_time(initial_datetime) as frozen_datetime:
-            test_cache_store.set("test_key", "test_value", ex=40)
-            assert test_cache_store.get("test_key") == "test_value"
-            assert test_cache_store._cache["test_key"].expired_at == datetime(
+            in_memory_cache.set("test_key", "test_value", ex=40)
+            assert in_memory_cache.get("test_key") == "test_value"
+            assert in_memory_cache._cache["test_key"].expired_at == datetime(
                 year=1, month=1, day=1, hour=15, minute=2, second=43
             )
 
             frozen_datetime.move_to(other_datetime)
 
-            assert test_cache_store.get("test_key") == "test_value"
-            assert test_cache_store._cache["test_key"].expired_at == datetime(
+            assert in_memory_cache.get("test_key") == "test_value"
+            assert in_memory_cache._cache["test_key"].expired_at == datetime(
                 year=1, month=1, day=1, hour=15, minute=2, second=43
             )
 
-    def test_set_and_get_after_expired_time(self, test_cache_store):
+    def test_set_and_get_after_expired_time(self, in_memory_cache):
         initial_datetime = datetime(
             year=1, month=1, day=1, hour=15, minute=2, second=3
         )
@@ -52,62 +63,157 @@ class TestInMemoryCacheStore:
         )
 
         with freeze_time(initial_datetime) as frozen_datetime:
-            test_cache_store.set("test_key", "test_value", ex=30)
-            assert test_cache_store.get("test_key") == "test_value"
-            assert test_cache_store._cache["test_key"].expired_at == datetime(
+            in_memory_cache.set("test_key", "test_value", ex=30)
+            assert in_memory_cache.get("test_key") == "test_value"
+            assert in_memory_cache._cache["test_key"].expired_at == datetime(
                 year=1, month=1, day=1, hour=15, minute=2, second=33
             )
 
             frozen_datetime.move_to(other_datetime)
 
-            assert test_cache_store.get("test_key") is None
-            assert "test_key" not in test_cache_store._cache
+            assert in_memory_cache.get("test_key") is None
+            assert "test_key" not in in_memory_cache._cache
 
     @freeze_time("2023-06-16 03:21:34 +02:00")
-    def test_expire_a_existing_key(self, test_cache_store):
-        test_cache_store.set("test_key", "test_value")
-        test_cache_store.expire("test_key", 30)
-        assert test_cache_store._cache["test_key"].expired_at == datetime(
+    def test_expire_a_existing_key(self, in_memory_cache):
+        in_memory_cache.set("test_key", "test_value")
+        in_memory_cache.expire("test_key", 30)
+        assert in_memory_cache._cache["test_key"].expired_at == datetime(
             year=2023, month=6, day=16, hour=1, minute=22, second=4
         )
 
     @freeze_time("2023-06-16 03:21:34 +02:00")
-    def test_expire_a_non_existing_key(self, test_cache_store):
-        test_cache_store.expire("test_key", 30)
-        assert "test_key" not in test_cache_store._cache
+    def test_expire_a_non_existing_key(self, in_memory_cache):
+        in_memory_cache.expire("test_key", 30)
+        assert "test_key" not in in_memory_cache._cache
 
-    def test_incr_a_non_existing_key(self, test_cache_store):
-        response = test_cache_store.incr("test_key")
+    def test_incr_a_non_existing_key(self, in_memory_cache):
+        response = in_memory_cache.incr("test_key")
         assert response == 1
-        assert test_cache_store.get("test_key") == 1
+        assert in_memory_cache.get("test_key") == 1
 
-    def test_incr_a_existing_key(self, test_cache_store):
-        test_cache_store.set("test_key", 1)
-        response = test_cache_store.incr("test_key")
+    def test_incr_a_existing_key(self, in_memory_cache):
+        in_memory_cache.set("test_key", 1)
+        response = in_memory_cache.incr("test_key")
         assert response == 2
-        assert test_cache_store.get("test_key") == 2
+        assert in_memory_cache.get("test_key") == 2
 
-    def test_incr_a_existing_key_not_a_number(self, test_cache_store):
-        test_cache_store.set("test_key", "not a number")
+    def test_incr_a_existing_key_not_a_number(self, in_memory_cache):
+        in_memory_cache.set("test_key", "not a number")
 
         with pytest.raises(TypeError, match="value is not an integer"):
-            test_cache_store.incr("test_key")
+            in_memory_cache.incr("test_key")
 
-    def test_flushdb(self, test_cache_store):
-        test_cache_store.set("test_key", "test_value")
-        test_cache_store.flushdb()
+    def test_flushdb(self, in_memory_cache):
+        in_memory_cache.set("test_key", "test_value")
+        in_memory_cache.flushdb()
 
-        assert test_cache_store._cache == {}
+        assert in_memory_cache._cache == {}
 
-    def test_delete_a_non_existing_key(self, test_cache_store):
-        test_cache_store.delete("test_key")
+    def test_delete_a_non_existing_key(self, in_memory_cache):
+        in_memory_cache.delete("test_key")
 
-        assert test_cache_store.get("test_key") is None
-        assert "test_key" not in test_cache_store._cache
+        assert in_memory_cache.get("test_key") is None
+        assert "test_key" not in in_memory_cache._cache
 
-    def test_delete_a_existing_key(self, test_cache_store):
-        test_cache_store.set("test_key", "test_value", ex=1000)
-        test_cache_store.delete("test_key")
+    def test_delete_a_existing_key(self, in_memory_cache):
+        in_memory_cache.set("test_key", "test_value", ex=1000)
+        in_memory_cache.delete("test_key")
 
-        assert test_cache_store.get("test_key") is None
-        assert "test_key" not in test_cache_store._cache
+        assert in_memory_cache.get("test_key") is None
+        assert "test_key" not in in_memory_cache._cache
+
+
+class TestHazelcastCacheStore:
+    def test_set_and_get(self, hazelcast_cache):
+        hazelcast_cache.set("test_key", "test_value")
+        assert hazelcast_cache.get("test_key") == "test_value"
+
+    @freeze_time("2023-06-16 03:21:34 +02:00")
+    def test_set_and_get_an_existing_key(self, hazelcast_cache):
+        hazelcast_cache.set("test_key", "test_value", ex=30)
+        assert hazelcast_cache.get("test_key") == "test_value"
+
+        hazelcast_cache.set("test_key", "test_value2")
+        assert hazelcast_cache.get("test_key") == "test_value2"
+
+    def test_set_and_get_before_expired_time(self, hazelcast_cache):
+        initial_datetime = datetime(
+            year=1, month=1, day=1, hour=15, minute=2, second=3
+        )
+        other_datetime = datetime(
+            year=1, month=1, day=1, hour=15, minute=2, second=34
+        )
+
+        with freeze_time(initial_datetime) as frozen_datetime:
+            hazelcast_cache.set("test_key", "test_value", ex=40)
+            assert hazelcast_cache.get("test_key") == "test_value"
+
+            frozen_datetime.move_to(other_datetime)
+
+            assert hazelcast_cache.get("test_key") == "test_value"
+
+    def test_set_and_get_after_expired_time(self, hazelcast_cache):
+        initial_datetime = datetime(
+            year=1, month=1, day=1, hour=15, minute=2, second=3
+        )
+        other_datetime = datetime(
+            year=1, month=1, day=1, hour=15, minute=2, second=34
+        )
+
+        with freeze_time(initial_datetime) as frozen_datetime:
+            hazelcast_cache.set("test_key", "test_value", ex=30)
+            assert hazelcast_cache.get("test_key") == "test_value"
+
+            frozen_datetime.move_to(other_datetime)
+            # NOTE: Hazelcast doesn't expire with freezegun
+            hazelcast_cache.delete("test_key")
+
+            assert hazelcast_cache.get("test_key") is None
+            assert not hazelcast_cache._cache.contains_key("test_key")
+
+    @freeze_time("2023-06-16 03:21:34 +02:00")
+    def test_expire_a_existing_key(self, hazelcast_cache):
+        hazelcast_cache.set("test_key", "test_value")
+        hazelcast_cache.expire("test_key", 30)
+
+    @freeze_time("2023-06-16 03:21:34 +02:00")
+    def test_expire_a_non_existing_key(self, hazelcast_cache):
+        hazelcast_cache.expire("test_key", 30)
+        assert not hazelcast_cache._cache.contains_key("test_key")
+
+    def test_incr_a_non_existing_key(self, hazelcast_cache):
+        response = hazelcast_cache.incr("test_key")
+        assert response == 1
+        assert hazelcast_cache.get("test_key") == 1
+
+    def test_incr_a_existing_key(self, hazelcast_cache):
+        hazelcast_cache.set("test_key", 1)
+        response = hazelcast_cache.incr("test_key")
+        assert response == 2
+        assert hazelcast_cache.get("test_key") == 2
+
+    def test_incr_a_existing_key_not_a_number(self, hazelcast_cache):
+        hazelcast_cache.set("test_key", "not a number")
+
+        with pytest.raises(TypeError, match="value is not an integer"):
+            hazelcast_cache.incr("test_key")
+
+    def test_flushdb(self, hazelcast_cache):
+        hazelcast_cache.set("test_key", "test_value")
+        hazelcast_cache.flushdb()
+
+        assert hazelcast_cache._cache.is_empty()
+
+    def test_delete_a_non_existing_key(self, hazelcast_cache):
+        hazelcast_cache.delete("test_key")
+
+        assert hazelcast_cache.get("test_key") is None
+        assert not hazelcast_cache._cache.contains_key("test_key")
+
+    def test_delete_a_existing_key(self, hazelcast_cache):
+        hazelcast_cache.set("test_key", "test_value", ex=1000)
+        hazelcast_cache.delete("test_key")
+
+        assert hazelcast_cache.get("test_key") is None
+        assert not hazelcast_cache._cache.contains_key("test_key")

--- a/tests/services/cache_test.py
+++ b/tests/services/cache_test.py
@@ -1,0 +1,105 @@
+import pytest
+from datetime import datetime
+from freezegun import freeze_time
+
+
+class TestInMemoryCacheStore:
+    def test_set_and_get(self, test_cache_store):
+        test_cache_store.set("test_key", "test_value")
+        assert test_cache_store.get("test_key") == "test_value"
+        assert test_cache_store.get("test_key:ttl") is None
+
+    @freeze_time("2023-06-16 03:21:34 +02:00")
+    def test_set_and_get_an_existing_key(self, test_cache_store):
+        test_cache_store.set("test_key", "test_value", ex=30)
+        assert test_cache_store.get("test_key") == "test_value"
+        assert test_cache_store.get("test_key:ttl") == datetime(
+            year=2023, month=6, day=16, hour=1, minute=22, second=4
+        )
+
+        test_cache_store.set("test_key", "test_value2")
+        assert test_cache_store.get("test_key") == "test_value2"
+        assert test_cache_store.get("test_key:ttl") is None
+
+    def test_set_and_get_before_ttl(self, test_cache_store):
+        initial_datetime = datetime(
+            year=1, month=1, day=1, hour=15, minute=2, second=3
+        )
+        other_datetime = datetime(
+            year=1, month=1, day=1, hour=15, minute=2, second=34
+        )
+
+        with freeze_time(initial_datetime) as frozen_datetime:
+            test_cache_store.set("test_key", "test_value", ex=40)
+            assert test_cache_store.get("test_key") == "test_value"
+            assert test_cache_store.get("test_key:ttl") == datetime(
+                year=1, month=1, day=1, hour=15, minute=2, second=43
+            )
+
+            frozen_datetime.move_to(other_datetime)
+
+            assert test_cache_store.get("test_key") == "test_value"
+            assert test_cache_store.get("test_key:ttl") == datetime(
+                year=1, month=1, day=1, hour=15, minute=2, second=43
+            )
+
+    def test_set_and_get_after_ttl(self, test_cache_store):
+        initial_datetime = datetime(
+            year=1, month=1, day=1, hour=15, minute=2, second=3
+        )
+        other_datetime = datetime(
+            year=1, month=1, day=1, hour=15, minute=2, second=34
+        )
+
+        with freeze_time(initial_datetime) as frozen_datetime:
+            test_cache_store.set("test_key", "test_value", ex=30)
+            assert test_cache_store.get("test_key") == "test_value"
+            assert test_cache_store.get("test_key:ttl") == datetime(
+                year=1, month=1, day=1, hour=15, minute=2, second=33
+            )
+
+            frozen_datetime.move_to(other_datetime)
+
+            assert test_cache_store.get("test_key") is None
+            assert test_cache_store.get("test_key:ttl") is None
+
+    @freeze_time("2023-06-16 03:21:34 +02:00")
+    def test_expire(self, test_cache_store):
+        test_cache_store.expire("test_key", 30)
+        assert test_cache_store.get("test_key:ttl") == datetime(
+            year=2023, month=6, day=16, hour=1, minute=22, second=4
+        )
+
+    def test_incr_a_non_existing_key(self, test_cache_store):
+        test_cache_store.incr("test_key")
+        assert test_cache_store.get("test_key") == 1
+
+    def test_incr_a_existing_key(self, test_cache_store):
+        test_cache_store.set("test_key", 1)
+        test_cache_store.incr("test_key")
+        assert test_cache_store.get("test_key") == 2
+
+    def test_incr_a_existing_key_not_a_number(self, test_cache_store):
+        test_cache_store.set("test_key", "not a number")
+
+        with pytest.raises(TypeError, match="value is not an integer"):
+            test_cache_store.incr("test_key")
+
+    def test_flushdb(self, test_cache_store):
+        test_cache_store.set("test_key", "test_value")
+        test_cache_store.flushdb()
+
+        assert test_cache_store._cache == {}
+
+    def test_delete_a_non_existing_key(self, test_cache_store):
+        test_cache_store.delete("test_key")
+
+        assert test_cache_store.get("test_key") is None
+        assert test_cache_store.get("test_key:ttl") is None
+
+    def test_delete_a_existing_key(self, test_cache_store):
+        test_cache_store.set("test_key", "test_value", ex=1000)
+        test_cache_store.delete("test_key")
+
+        assert test_cache_store.get("test_key") is None
+        assert test_cache_store.get("test_key:ttl") is None

--- a/tests/services/circuit_breaker_test.py
+++ b/tests/services/circuit_breaker_test.py
@@ -52,6 +52,11 @@ def test_protected_call_too_many_failures_not_in_a_row(
             )
 
         frozen_datetime.move_to(other_datetime)
+
+        # NOTE: Hazelcast doesn't expire with freezegun
+        test_cache_store.delete("test_key:status")
+        test_cache_store.delete("test_key:num_failures")
+
         with pytest.raises(KeyError, match="foo"):
             CircuitBreaker.protected_call(
                 func=mock_function,

--- a/tests/services/circuit_breaker_test.py
+++ b/tests/services/circuit_breaker_test.py
@@ -1,0 +1,81 @@
+from datetime import datetime
+import pytest
+from freezegun import freeze_time
+from app.services.circuit_breaker import CircuitBreaker
+
+
+def test_protected_call_success(mocker):
+    mock_function = mocker.MagicMock(return_value=3)
+
+    result = CircuitBreaker.protected_call(
+        func=mock_function, cache_key="test_key"
+    )
+
+    mock_function.assert_called_once()
+    assert result == 3
+
+
+def test_protected_call_fail_with_accepted_exceptions(
+    mocker, test_cache_store
+):
+    mock_function = mocker.MagicMock(side_effect=KeyError("foo"))
+
+    with pytest.raises(KeyError, match="foo"):
+        CircuitBreaker.protected_call(
+            func=mock_function,
+            cache_key="test_key",
+            accepted_exceptions=(KeyError,),
+        )
+
+    assert test_cache_store.get("test_key:num_failures") is None
+
+
+@freeze_time("2023-06-16 03:21:34 +02:00")
+def test_protected_call_too_many_failures_not_in_a_row(
+    mocker, test_cache_store
+):
+    initial_datetime = datetime(
+        year=1, month=1, day=1, hour=15, minute=2, second=3
+    )
+    other_datetime = datetime(
+        year=1, month=1, day=1, hour=15, minute=2, second=34
+    )
+
+    with freeze_time(initial_datetime) as frozen_datetime:
+        test_cache_store.set("test_key:num_failures", 2)
+        mock_function = mocker.MagicMock(side_effect=KeyError("foo"))
+
+        with pytest.raises(KeyError, match="foo"):
+            CircuitBreaker.protected_call(
+                func=mock_function,
+                cache_key="test_key",
+            )
+
+        frozen_datetime.move_to(other_datetime)
+        with pytest.raises(KeyError, match="foo"):
+            CircuitBreaker.protected_call(
+                func=mock_function,
+                cache_key="test_key",
+            )
+        assert test_cache_store.get("test_key:num_failures") == 1
+
+
+def test_protected_call_too_many_failures_in_a_row(mocker, test_cache_store):
+    test_cache_store.set("test_key:num_failures", 2)
+    mock_function = mocker.MagicMock(side_effect=KeyError("foo"))
+
+    with pytest.raises(KeyError, match="foo"):
+        CircuitBreaker.protected_call(
+            func=mock_function,
+            cache_key="test_key",
+        )
+
+    with pytest.raises(
+        ValueError, match="Too many failures! Please try again later."
+    ):
+        CircuitBreaker.protected_call(
+            func=mock_function,
+            cache_key="test_key",
+        )
+
+    assert test_cache_store.get("test_key:num_failures") == 3


### PR DESCRIPTION
## Description
- Protect function call with circuit breaker: 
  + if the circuit is open, a function call will raise "too many failures" error
  + if the circuit is closed, perform the function call will:
    ++ if call successfully, set the circuit status to closed and cache this result for 5 minutes
    ++ if call unsuccessfully, set the circuit status to open and cache this result for 30 seconds
- Add health endpoint to return UP (the circuit is closed) and DOWN (the circuit is open) status for each model. This endpoint is called by Artermis regularly, so it will try to get the status from the cache before calling to get new status

## Step for testing
- Purposely set wrong config for one model or just use the values from `application.example.yml`
- Call `POST /api/v1/messages` for 3 times for that model, and the fourth time will have "too many failures" error
- Wait for 30 seconds and can continue to call that model
- Call `GET /api/v1/health` and should have the correct status for the models