### PR TITLE
Update how guidance handle error when missing params for the handlebar

### DIFF
--- a/app/services/guidance_wrapper.py
+++ b/app/services/guidance_wrapper.py
@@ -24,6 +24,7 @@ class GuidanceWrapper:
             Text content object with LLM's response.
 
         Raises:
+            Reraises exception from guidance package
             ValueError: if handlebars do not generate 'response'
         """
 
@@ -32,6 +33,9 @@ class GuidanceWrapper:
             llm=self._get_llm(),
             **self.parameters,
         )
+
+        if isinstance(result._exception, Exception):
+            raise result._exception
 
         if "response" not in result:
             raise ValueError("The handlebars do not generate 'response'")

--- a/tests/services/guidance_wrapper_test.py
+++ b/tests/services/guidance_wrapper_test.py
@@ -34,9 +34,6 @@ def test_query_success(mocker):
     assert result.text_content == "the output"
 
 
-@pytest.mark.skip(
-    reason="This tests library behavior changed by Guidance version bump"
-)
 def test_query_missing_required_params(mocker):
     mocker.patch.object(
         GuidanceWrapper,
@@ -55,14 +52,11 @@ def test_query_missing_required_params(mocker):
     )
 
     with pytest.raises(KeyError, match="Command/variable 'query' not found!"):
-        # try:
         result = guidance_wrapper.query()
 
         assert isinstance(result, Content)
         assert result.type == ContentType.TEXT
         assert result.text_content == "the output"
-    # except Exception as e:
-    #     pass
 
 
 def test_query_handlebars_not_generate_response(mocker):


### PR DESCRIPTION
# Description
From guidance 0.0.64, if we query a handlebar for example like this:
```
{{#user~}}{{query}}{{~/user}}{{#assistant~}}{{gen 'response' temperature=0.0 max_tokens=10}}{{~/assistant}}
```

We need to specify `query` to the parameters. 

Before, missing this value will raise KeyError
Now, guidance won't raise any error and just won't generate a response