### PR TITLE
`Development`: Add V2 Messages Endpoint

### DIFF
--- a/app/models/dtos.py
+++ b/app/models/dtos.py
@@ -21,7 +21,6 @@ class Content(BaseModel):
 
 class SendMessageRequest(BaseModel):
     class Template(BaseModel):
-        id: int
         content: str
 
     template: Template

--- a/app/models/dtos.py
+++ b/app/models/dtos.py
@@ -13,6 +13,12 @@ class ContentType(str, Enum):
     TEXT = "text"
 
 
+# V1 API only
+class Content(BaseModel):
+    text_content: str = Field(..., alias="textContent")
+    type: ContentType
+
+
 class SendMessageRequest(BaseModel):
     class Template(BaseModel):
         id: int
@@ -23,7 +29,19 @@ class SendMessageRequest(BaseModel):
     parameters: dict
 
 
+# V1 API only
 class SendMessageResponse(BaseModel):
+    class Message(BaseModel):
+        sent_at: datetime = Field(
+            alias="sentAt", default_factory=datetime.utcnow
+        )
+        content: list[Content]
+
+    used_model: str = Field(..., alias="usedModel")
+    message: Message
+
+
+class SendMessageResponseV2(BaseModel):
     used_model: str = Field(..., alias="usedModel")
     sent_at: datetime = Field(alias="sentAt", default_factory=datetime.utcnow)
     content: dict

--- a/app/models/dtos.py
+++ b/app/models/dtos.py
@@ -25,9 +25,7 @@ class SendMessageRequest(BaseModel):
 
 class SendMessageResponse(BaseModel):
     used_model: str = Field(..., alias="usedModel")
-    sent_at: datetime = Field(
-        alias="sentAt", default_factory=datetime.utcnow
-    )
+    sent_at: datetime = Field(alias="sentAt", default_factory=datetime.utcnow)
     content: dict
 
 

--- a/app/models/dtos.py
+++ b/app/models/dtos.py
@@ -40,6 +40,12 @@ class SendMessageResponse(BaseModel):
     message: Message
 
 
+class SendMessageRequestV2(BaseModel):
+    template: str
+    preferred_model: str = Field(..., alias="preferredModel")
+    parameters: dict
+
+
 class SendMessageResponseV2(BaseModel):
     used_model: str = Field(..., alias="usedModel")
     sent_at: datetime = Field(alias="sentAt", default_factory=datetime.utcnow)

--- a/app/models/dtos.py
+++ b/app/models/dtos.py
@@ -13,11 +13,6 @@ class ContentType(str, Enum):
     TEXT = "text"
 
 
-class Content(BaseModel):
-    text_content: str = Field(..., alias="textContent")
-    type: ContentType
-
-
 class SendMessageRequest(BaseModel):
     class Template(BaseModel):
         id: int
@@ -29,14 +24,11 @@ class SendMessageRequest(BaseModel):
 
 
 class SendMessageResponse(BaseModel):
-    class Message(BaseModel):
-        sent_at: datetime = Field(
-            alias="sentAt", default_factory=datetime.utcnow
-        )
-        content: list[Content]
-
     used_model: str = Field(..., alias="usedModel")
-    message: Message
+    sent_at: datetime = Field(
+        alias="sentAt", default_factory=datetime.utcnow
+    )
+    content: dict
 
 
 class ModelStatus(BaseModel):

--- a/app/routes/messages.py
+++ b/app/routes/messages.py
@@ -62,7 +62,7 @@ def execute_call(body: SendMessageRequest) -> dict:
 def send_message(body: SendMessageRequest) -> SendMessageResponse:
     generated_vars = execute_call(body)
 
-    # Restore the old behavior of only returning the 'response' variable for the v1 API
+    # Restore the old behavior of throwing an exception if no 'response' variable was generated
     if "response" not in generated_vars:
         raise InternalServerException(
             str(ValueError("The handlebars do not generate 'response'"))
@@ -75,7 +75,7 @@ def send_message(body: SendMessageRequest) -> SendMessageResponse:
             content=[
                 Content(
                     type=ContentType.TEXT,
-                    textContent=generated_vars["response"],
+                    textContent=generated_vars["response"],  # V1 behavior: only return the 'response' variable
                 )
             ],
         ),
@@ -91,5 +91,5 @@ def send_message_v2(body: SendMessageRequest) -> SendMessageResponseV2:
     return SendMessageResponseV2(
         usedModel=body.preferred_model,
         sentAt=datetime.now(timezone.utc),
-        content=generated_vars,
+        content=generated_vars,  # V2 behavior: return all variables generated in the program
     )

--- a/app/routes/messages.py
+++ b/app/routes/messages.py
@@ -61,7 +61,9 @@ def execute_call(template, preferred_model, parameters) -> dict:
     "/api/v1/messages", dependencies=[Depends(TokenPermissionsValidator())]
 )
 def send_message(body: SendMessageRequest) -> SendMessageResponse:
-    generated_vars = execute_call(body.template.content, body.preferred_model, body.parameters)
+    generated_vars = execute_call(
+        body.template.content, body.preferred_model, body.parameters
+    )
 
     # V1: Throw an exception if no 'response' variable was generated
     if "response" not in generated_vars:
@@ -89,7 +91,9 @@ def send_message(body: SendMessageRequest) -> SendMessageResponse:
     "/api/v2/messages", dependencies=[Depends(TokenPermissionsValidator())]
 )
 def send_message_v2(body: SendMessageRequestV2) -> SendMessageResponseV2:
-    generated_vars = execute_call(body.template, body.preferred_model, body.parameters)
+    generated_vars = execute_call(
+        body.template, body.preferred_model, body.parameters
+    )
 
     return SendMessageResponseV2(
         usedModel=body.preferred_model,

--- a/app/routes/messages.py
+++ b/app/routes/messages.py
@@ -75,7 +75,9 @@ def send_message(body: SendMessageRequest) -> SendMessageResponse:
             content=[
                 Content(
                     type=ContentType.TEXT,
-                    textContent=generated_vars["response"],  # V1 behavior: only return the 'response' variable
+                    textContent=generated_vars[
+                        "response"
+                    ],  # V1 behavior: only return the 'response' variable
                 )
             ],
         ),

--- a/app/routes/messages.py
+++ b/app/routes/messages.py
@@ -16,6 +16,7 @@ from app.models.dtos import (
     SendMessageResponse,
     Content,
     ContentType,
+    SendMessageRequestV2,
     SendMessageResponseV2,
 )
 from app.services.circuit_breaker import CircuitBreaker
@@ -25,22 +26,22 @@ from app.config import settings
 router = APIRouter(tags=["messages"])
 
 
-def execute_call(body: SendMessageRequest) -> dict:
+def execute_call(template, preferred_model, parameters) -> dict:
     try:
-        model = settings.pyris.llms[body.preferred_model]
+        model = settings.pyris.llms[preferred_model]
     except ValueError as e:
         raise InvalidModelException(str(e))
 
     guidance = GuidanceWrapper(
         model=model,
-        handlebars=body.template.content,
-        parameters=body.parameters,
+        handlebars=template,
+        parameters=parameters,
     )
 
     try:
         return CircuitBreaker.protected_call(
             func=guidance.query,
-            cache_key=body.preferred_model,
+            cache_key=preferred_model,
             accepted_exceptions=(
                 KeyError,
                 SyntaxError,
@@ -60,7 +61,7 @@ def execute_call(body: SendMessageRequest) -> dict:
     "/api/v1/messages", dependencies=[Depends(TokenPermissionsValidator())]
 )
 def send_message(body: SendMessageRequest) -> SendMessageResponse:
-    generated_vars = execute_call(body)
+    generated_vars = execute_call(body.template.content, body.preferred_model, body.parameters)
 
     # V1: Throw an exception if no 'response' variable was generated
     if "response" not in generated_vars:
@@ -87,8 +88,8 @@ def send_message(body: SendMessageRequest) -> SendMessageResponse:
 @router.post(
     "/api/v2/messages", dependencies=[Depends(TokenPermissionsValidator())]
 )
-def send_message_v2(body: SendMessageRequest) -> SendMessageResponseV2:
-    generated_vars = execute_call(body)
+def send_message_v2(body: SendMessageRequestV2) -> SendMessageResponseV2:
+    generated_vars = execute_call(body.template, body.preferred_model, body.parameters)
 
     return SendMessageResponseV2(
         usedModel=body.preferred_model,

--- a/app/routes/messages.py
+++ b/app/routes/messages.py
@@ -52,13 +52,8 @@ def send_message(body: SendMessageRequest) -> SendMessageResponse:
     except Exception as e:
         raise InternalServerException(str(e))
 
-    # Turn content into an array if it's not already
-    if not isinstance(content, list):
-        content = [content]
-
     return SendMessageResponse(
         usedModel=body.preferred_model,
-        message=SendMessageResponse.Message(
-            sentAt=datetime.now(timezone.utc), content=content
-        ),
+        sentAt=datetime.now(timezone.utc),
+        content=content,
     )

--- a/app/routes/messages.py
+++ b/app/routes/messages.py
@@ -62,7 +62,7 @@ def execute_call(body: SendMessageRequest) -> dict:
 def send_message(body: SendMessageRequest) -> SendMessageResponse:
     generated_vars = execute_call(body)
 
-    # Restore the old behavior of throwing an exception if no 'response' variable was generated
+    # V1: Throw an exception if no 'response' variable was generated
     if "response" not in generated_vars:
         raise InternalServerException(
             str(ValueError("The handlebars do not generate 'response'"))
@@ -77,7 +77,7 @@ def send_message(body: SendMessageRequest) -> SendMessageResponse:
                     type=ContentType.TEXT,
                     textContent=generated_vars[
                         "response"
-                    ],  # V1 behavior: only return the 'response' variable
+                    ],  # V1: only return the 'response' variable
                 )
             ],
         ),
@@ -93,5 +93,5 @@ def send_message_v2(body: SendMessageRequest) -> SendMessageResponseV2:
     return SendMessageResponseV2(
         usedModel=body.preferred_model,
         sentAt=datetime.now(timezone.utc),
-        content=generated_vars,  # V2 behavior: return all variables generated in the program
+        content=generated_vars,  # V2: return all generated variables
     )

--- a/app/services/guidance_wrapper.py
+++ b/app/services/guidance_wrapper.py
@@ -32,6 +32,10 @@ class GuidanceWrapper:
             ValueError: if handlebars do not generate 'response'
         """
 
+        import re
+        pattern = r'{{(?:gen|geneach|set) [\'"]([^\'"]+)[\'"]$}}'
+        var_names = re.findall(pattern, input_string)
+
         template = guidance(self.handlebars)
         result = template(
             llm=self._get_llm(),
@@ -42,10 +46,11 @@ class GuidanceWrapper:
         if isinstance(result._exception, Exception):
             raise result._exception
 
-        if "response" not in result:
-            raise ValueError("The handlebars do not generate 'response'")
+        generated_vars = {
+            var_name: result[var_name] for var_name in var_names if var_name in result
+        }
 
-        return Content(type=ContentType.TEXT, textContent=result["response"])
+        return generated_vars
 
     def is_up(self) -> bool:
         """Check if the chosen LLM model is up.

--- a/app/services/guidance_wrapper.py
+++ b/app/services/guidance_wrapper.py
@@ -1,4 +1,5 @@
 import guidance
+import re
 
 from app.config import LLMModelConfig
 from app.services.guidance_functions import truncate
@@ -28,15 +29,13 @@ class GuidanceWrapper:
 
         Raises:
             Reraises exception from guidance package
-            ValueError: if handlebars do not generate 'response'
         """
 
         # Perform a regex search to find the names of the variables being generated
         # by the handlebars template
         # This regex matches strings like: {{gen 'response' temperature=0.0 max_tokens=500}}
         # and extracts the variable name 'response'
-        import re
-        pattern = r'{{(?:gen|geneach|set) [\'"]([^\'"]+)[\'"]$}}'
+        pattern = r'{{#?(?:gen|geneach|set) +[\'"]([^\'"]+)[\'"]'
         var_names = re.findall(pattern, self.handlebars)
 
         template = guidance(self.handlebars)

--- a/app/services/guidance_wrapper.py
+++ b/app/services/guidance_wrapper.py
@@ -31,10 +31,12 @@ class GuidanceWrapper:
             Reraises exception from guidance package
         """
 
-        # Perform a regex search to find the names of the variables being generated
-        # by the handlebars template
-        # This regex matches strings like: {{gen 'response' temperature=0.0 max_tokens=500}}
-        # and extracts the variable name 'response'
+        # Perform a regex search to find the names of the variables
+        # being generated in the program. This regex matches strings like:
+        #    {{gen 'response' temperature=0.0 max_tokens=500}}
+        #    {{#geneach 'values' num_iterations=3}}
+        #    {{set 'answer' (truncate response 3)}}
+        # and extracts the variable names 'response', 'values', and 'answer'
         pattern = r'{{#?(?:gen|geneach|set) +[\'"]([^\'"]+)[\'"]'
         var_names = re.findall(pattern, self.handlebars)
 

--- a/app/services/guidance_wrapper.py
+++ b/app/services/guidance_wrapper.py
@@ -31,8 +31,11 @@ class GuidanceWrapper:
             ValueError: if handlebars do not generate 'response'
         """
 
+        # Perform a regex search to find the names of the variables being generated
+        # by the handlebars template
+        # This regex matches strings like: {{gen 'response' temperature=0.0 max_tokens=500}}
+        # and extracts the variable name 'response'
         import re
-
         pattern = r'{{(?:gen|geneach|set) [\'"]([^\'"]+)[\'"]$}}'
         var_names = re.findall(pattern, self.handlebars)
 

--- a/app/services/guidance_wrapper.py
+++ b/app/services/guidance_wrapper.py
@@ -1,7 +1,6 @@
 import guidance
 
 from app.config import LLMModelConfig
-from app.models.dtos import Content, ContentType
 from app.services.guidance_functions import truncate
 
 
@@ -21,7 +20,7 @@ class GuidanceWrapper:
         self.handlebars = handlebars
         self.parameters = parameters
 
-    def query(self) -> Content:
+    def query(self) -> dict:
         """Get response from a chosen LLM model.
 
         Returns:
@@ -33,8 +32,9 @@ class GuidanceWrapper:
         """
 
         import re
+
         pattern = r'{{(?:gen|geneach|set) [\'"]([^\'"]+)[\'"]$}}'
-        var_names = re.findall(pattern, input_string)
+        var_names = re.findall(pattern, self.handlebars)
 
         template = guidance(self.handlebars)
         result = template(
@@ -47,7 +47,9 @@ class GuidanceWrapper:
             raise result._exception
 
         generated_vars = {
-            var_name: result[var_name] for var_name in var_names if var_name in result
+            var_name: result[var_name]
+            for var_name in var_names
+            if var_name in result
         }
 
         return generated_vars
@@ -69,7 +71,7 @@ class GuidanceWrapper:
         content = (
             GuidanceWrapper(model=self.model, handlebars=handlebars)
             .query()
-            .text_content
+            .get("response")
         )
         return content == "1"
 

--- a/tests/routes/messages_test.py
+++ b/tests/routes/messages_test.py
@@ -50,9 +50,19 @@ def test_send_message(test_client, headers, mocker):
             "query": "Some query",
         },
     }
-    response = test_client.post("/api/v1/messages", headers=headers, json=body)
-    assert response.status_code == 200
-    assert response.json() == {
+    response_v1 = test_client.post("/api/v1/messages", headers=headers, json=body)
+    assert response_v1.status_code == 200
+    assert response_v1.json() == {
+        "usedModel": "GPT35_TURBO",
+        "message": {
+            "sentAt": "2023-06-16T01:21:34+00:00",
+            "content": [{"textContent": "some content", "type": "text"}],
+        },
+    }
+
+    response_v2 = test_client.post("/api/v2/messages", headers=headers, json=body)
+    assert response_v2.status_code == 200
+    assert response_v2.json() == {
         "usedModel": "GPT35_TURBO",
         "sentAt": "2023-06-16T01:21:34+00:00",
         "content": {

--- a/tests/routes/messages_test.py
+++ b/tests/routes/messages_test.py
@@ -62,6 +62,31 @@ def test_send_message(test_client, headers, mocker):
         },
     }
 
+
+@freeze_time("2023-06-16 03:21:34 +02:00")
+@pytest.mark.usefixtures("model_configs")
+def test_send_message_v2(test_client, headers, mocker):
+    mocker.patch.object(
+        GuidanceWrapper,
+        "query",
+        return_value={
+            "response": "some content",
+        },
+        autospec=True,
+    )
+
+    body = {
+        "template": "{{#user~}}I want a response to the following query:\
+            {{query}}{{~/user}}{{#assistant~}}\
+            {{gen 'response' temperature=0.0 max_tokens=500}}{{~/assistant}}",
+        "preferredModel": "GPT35_TURBO",
+        "parameters": {
+            "course": "Intro to Java",
+            "exercise": "Fun With Sets",
+            "query": "Some query",
+        },
+    }
+
     response_v2 = test_client.post(
         "/api/v2/messages", headers=headers, json=body
     )

--- a/tests/routes/messages_test.py
+++ b/tests/routes/messages_test.py
@@ -50,7 +50,9 @@ def test_send_message(test_client, headers, mocker):
             "query": "Some query",
         },
     }
-    response_v1 = test_client.post("/api/v1/messages", headers=headers, json=body)
+    response_v1 = test_client.post(
+        "/api/v1/messages", headers=headers, json=body
+    )
     assert response_v1.status_code == 200
     assert response_v1.json() == {
         "usedModel": "GPT35_TURBO",
@@ -60,7 +62,9 @@ def test_send_message(test_client, headers, mocker):
         },
     }
 
-    response_v2 = test_client.post("/api/v2/messages", headers=headers, json=body)
+    response_v2 = test_client.post(
+        "/api/v2/messages", headers=headers, json=body
+    )
     assert response_v2.status_code == 200
     assert response_v2.json() == {
         "usedModel": "GPT35_TURBO",

--- a/tests/routes/messages_test.py
+++ b/tests/routes/messages_test.py
@@ -1,6 +1,5 @@
 import pytest
 from freezegun import freeze_time
-from app.models.dtos import Content, ContentType
 from app.services.guidance_wrapper import GuidanceWrapper
 import app.config as config
 

--- a/tests/routes/messages_test.py
+++ b/tests/routes/messages_test.py
@@ -31,9 +31,9 @@ def test_send_message(test_client, headers, mocker):
     mocker.patch.object(
         GuidanceWrapper,
         "query",
-        return_value=Content(
-            type=ContentType.TEXT, textContent="some content"
-        ),
+        return_value={
+            "response": "some content",
+        },
         autospec=True,
     )
 
@@ -55,9 +55,9 @@ def test_send_message(test_client, headers, mocker):
     assert response.status_code == 200
     assert response.json() == {
         "usedModel": "GPT35_TURBO",
-        "message": {
-            "sentAt": "2023-06-16T01:21:34+00:00",
-            "content": [{"textContent": "some content", "type": "text"}],
+        "sentAt": "2023-06-16T01:21:34+00:00",
+        "content": {
+            "response": "some content",
         },
     }
 

--- a/tests/services/guidance_wrapper_test.py
+++ b/tests/services/guidance_wrapper_test.py
@@ -1,7 +1,6 @@
 import pytest
 import guidance
 
-from app.models.dtos import Content, ContentType
 from app.services.guidance_wrapper import GuidanceWrapper
 from app.config import OpenAIConfig
 
@@ -33,9 +32,8 @@ def test_query_success(mocker):
 
     result = guidance_wrapper.query()
 
-    assert isinstance(result, Content)
-    assert result.type == ContentType.TEXT
-    assert result.text_content == "the output"
+    assert isinstance(result, dict)
+    assert result['response'] == "the output"
 
 
 def test_query_using_truncate_function(mocker):
@@ -59,9 +57,9 @@ def test_query_using_truncate_function(mocker):
 
     result = guidance_wrapper.query()
 
-    assert isinstance(result, Content)
-    assert result.type == ContentType.TEXT
-    assert result.text_content == "the"
+    assert isinstance(result, dict)
+    assert result['answer'] == "the output"
+    assert result['response'] == "the"
 
 
 def test_query_missing_required_params(mocker):
@@ -84,30 +82,5 @@ def test_query_missing_required_params(mocker):
     with pytest.raises(KeyError, match="Command/variable 'query' not found!"):
         result = guidance_wrapper.query()
 
-        assert isinstance(result, Content)
-        assert result.type == ContentType.TEXT
-        assert result.text_content == "the output"
-
-
-def test_query_handlebars_not_generate_response(mocker):
-    mocker.patch.object(
-        GuidanceWrapper,
-        "_get_llm",
-        return_value=guidance.llms.Mock("the output"),
-    )
-
-    handlebars = "Not a valid handlebars"
-    guidance_wrapper = GuidanceWrapper(
-        model=llm_model_config,
-        handlebars=handlebars,
-        parameters={"query": "Something"},
-    )
-
-    with pytest.raises(
-        ValueError, match="The handlebars do not generate 'response'"
-    ):
-        result = guidance_wrapper.query()
-
-        assert isinstance(result, Content)
-        assert result.type == ContentType.TEXT
-        assert result.text_content == "the output"
+        assert isinstance(result, dict)
+        assert result['response'] == "the output"

--- a/tests/services/guidance_wrapper_test.py
+++ b/tests/services/guidance_wrapper_test.py
@@ -33,7 +33,7 @@ def test_query_success(mocker):
     result = guidance_wrapper.query()
 
     assert isinstance(result, dict)
-    assert result['response'] == "the output"
+    assert result["response"] == "the output"
 
 
 def test_query_using_truncate_function(mocker):
@@ -58,8 +58,8 @@ def test_query_using_truncate_function(mocker):
     result = guidance_wrapper.query()
 
     assert isinstance(result, dict)
-    assert result['answer'] == "the output"
-    assert result['response'] == "the"
+    assert result["answer"] == "the output"
+    assert result["response"] == "the"
 
 
 def test_query_missing_required_params(mocker):
@@ -83,4 +83,4 @@ def test_query_missing_required_params(mocker):
         result = guidance_wrapper.query()
 
         assert isinstance(result, dict)
-        assert result['response'] == "the output"
+        assert result["response"] == "the output"


### PR DESCRIPTION
This PR introduces a version 2 of the messages endpoint, which returns all content generated in a guidance program as opposed to just the one variable titled 'response', and additionally accepts just a string as the template parameter instead of an object containing a string and an unused id.