### PR TITLE
`Bugfix`: Fix several issues relating to GPT4

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,17 +4,15 @@ import types
 from guidance.llms import OpenAI
 import guidance.llms._openai
 from pyaml_env import parse_config
-from pydantic import BaseModel, validator, Field, typing
+from pydantic import BaseModel, validator
 
 old_add_text_to_chat_mode = guidance.llms._openai.add_text_to_chat_mode
 
 
 def new_add_text_to_chat_mode(chat_mode):
     if isinstance(chat_mode, (types.AsyncGeneratorType, types.GeneratorType)):
-        print("new_add_text_to_chat_mode", chat_mode)
         return guidance.llms._openai.add_text_to_chat_mode_generator(chat_mode)
     else:
-        print("new_add_text_to_chat_mode", chat_mode.items())
         for c in chat_mode["choices"]:
             if "message" in c and "content" in c["message"]:
                 c["text"] = c["message"]["content"]
@@ -42,7 +40,6 @@ class LLMModelConfig(BaseModel):
 class OpenAIConfig(LLMModelConfig):
     spec: LLMModelSpecs
     llm_credentials: dict
-    instance: typing.Any = Field(repr=False)
 
     @validator("type")
     def check_type(cls, v):
@@ -52,15 +49,10 @@ class OpenAIConfig(LLMModelConfig):
 
     def get_instance(cls):
         return OpenAI(**cls.llm_credentials)
-        # if cls.instance is not None:
-        #     return cls.instance
-        # cls.instance = OpenAI(**cls.llm_credentials)
-        # return cls.instance
 
 
 class StrategyLLMConfig(LLMModelConfig):
     llms: list[str]
-    instance: typing.Any = Field(repr=False)
 
     @validator("type")
     def check_type(cls, v):
@@ -72,13 +64,6 @@ class StrategyLLMConfig(LLMModelConfig):
         from app.llms.strategy_llm import StrategyLLM
 
         return StrategyLLM(cls.llms)
-        # if#  cls.instance is not None:
-        #     return cls.instance
-        # # Local import needed to avoid circular dependency
-        # from app.llms.strategy_llm import StrategyLLM
-        #
-        # cls.instance = StrategyLLM(cls.llms)
-        # return cls.instance
 
 
 class APIKeyConfig(BaseModel):

--- a/app/config.py
+++ b/app/config.py
@@ -16,7 +16,10 @@ def new_add_text_to_chat_mode(chat_mode):
     else:
         print("new_add_text_to_chat_mode", chat_mode.items())
         for c in chat_mode["choices"]:
-            c["text"] = c["message"]["content"]
+            if "message" in c and "content" in c["message"]:
+                c["text"] = c["message"]["content"]
+            else:
+                c["text"] = ""
         return chat_mode
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,8 +1,26 @@
 import os
+import types
 
 from guidance.llms import OpenAI
+import guidance.llms._openai
 from pyaml_env import parse_config
 from pydantic import BaseModel, validator, Field, typing
+
+old_add_text_to_chat_mode = guidance.llms._openai.add_text_to_chat_mode
+
+
+def new_add_text_to_chat_mode(chat_mode):
+    if isinstance(chat_mode, (types.AsyncGeneratorType, types.GeneratorType)):
+        print("new_add_text_to_chat_mode", chat_mode)
+        return guidance.llms._openai.add_text_to_chat_mode_generator(chat_mode)
+    else:
+        print("new_add_text_to_chat_mode", chat_mode.items())
+        for c in chat_mode["choices"]:
+            c["text"] = c["message"]["content"]
+        return chat_mode
+
+
+guidance.llms._openai.add_text_to_chat_mode = new_add_text_to_chat_mode
 
 
 class LLMModelSpecs(BaseModel):

--- a/app/config.py
+++ b/app/config.py
@@ -19,7 +19,7 @@ def new_add_text_to_chat_mode(chat_mode):
             if "message" in c and "content" in c["message"]:
                 c["text"] = c["message"]["content"]
             else:
-                c["text"] = ""
+                c["text"] = None
         return chat_mode
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -19,7 +19,7 @@ def new_add_text_to_chat_mode(chat_mode):
             if "message" in c and "content" in c["message"]:
                 c["text"] = c["message"]["content"]
             else:
-                c["text"] = None
+                c["text"] = " "
         return chat_mode
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,6 @@
 import os
 import types
-
+import copy
 from guidance.llms import OpenAI
 import guidance.llms._openai
 from pyaml_env import parse_config
@@ -48,7 +48,9 @@ class OpenAIConfig(LLMModelConfig):
         return v
 
     def get_instance(cls):
-        return OpenAI(**cls.llm_credentials)
+        print("Specs", cls.llm_credentials)
+        llm_credentials = copy.deepcopy(cls.llm_credentials)
+        return OpenAI(**llm_credentials)
 
 
 class StrategyLLMConfig(LLMModelConfig):

--- a/app/config.py
+++ b/app/config.py
@@ -30,10 +30,11 @@ class OpenAIConfig(LLMModelConfig):
         return v
 
     def get_instance(cls):
-        if cls.instance is not None:
-            return cls.instance
-        cls.instance = OpenAI(**cls.llm_credentials)
-        return cls.instance
+        return OpenAI(**cls.llm_credentials)
+        # if cls.instance is not None:
+        #     return cls.instance
+        # cls.instance = OpenAI(**cls.llm_credentials)
+        # return cls.instance
 
 
 class StrategyLLMConfig(LLMModelConfig):
@@ -47,13 +48,16 @@ class StrategyLLMConfig(LLMModelConfig):
         return v
 
     def get_instance(cls):
-        if cls.instance is not None:
-            return cls.instance
-        # Local import needed to avoid circular dependency
         from app.llms.strategy_llm import StrategyLLM
 
-        cls.instance = StrategyLLM(cls.llms)
-        return cls.instance
+        return StrategyLLM(cls.llms)
+        # if#  cls.instance is not None:
+        #     return cls.instance
+        # # Local import needed to avoid circular dependency
+        # from app.llms.strategy_llm import StrategyLLM
+        #
+        # cls.instance = StrategyLLM(cls.llms)
+        # return cls.instance
 
 
 class APIKeyConfig(BaseModel):

--- a/app/services/circuit_breaker.py
+++ b/app/services/circuit_breaker.py
@@ -135,5 +135,7 @@ class CircuitBreaker:
                 )
                 return cls.Status.CLOSED
 
-            cache_store.set(status_key, cls.Status.OPEN, ex=cls.OPEN_TTL_SECONDS)
+            cache_store.set(
+                status_key, cls.Status.OPEN, ex=cls.OPEN_TTL_SECONDS
+            )
             return cls.Status.OPEN

--- a/app/services/circuit_breaker.py
+++ b/app/services/circuit_breaker.py
@@ -1,6 +1,9 @@
 import logging
 from enum import Enum
 from app.services.cache import cache_store
+from threading import Lock
+
+health_locks = {}
 
 log = logging.getLogger(__name__)
 
@@ -109,23 +112,28 @@ class CircuitBreaker:
         Returns: Status of the cache_key.
         Circuit is CLOSED if cache_key is up and running, and OPEN otherwise.
         """
-        status_key = f"{cache_key}:status"
-        status = cache_store.get(status_key)
+        if cache_key not in health_locks:
+            health_locks[cache_key] = Lock()
 
-        if status:
-            return cls.Status(status)
+        # Acquire the lock
+        with health_locks[cache_key]:
+            status_key = f"{cache_key}:status"
+            status = cache_store.get(status_key)
 
-        is_up = False
-        try:
-            is_up = checkhealth_func()
-        except Exception as e:
-            log.error(e)
+            if status:
+                return cls.Status(status)
 
-        if is_up:
-            cache_store.set(
-                status_key, cls.Status.CLOSED, ex=cls.CLOSED_TTL_SECONDS
-            )
-            return cls.Status.CLOSED
+            is_up = False
+            try:
+                is_up = checkhealth_func()
+            except Exception as e:
+                log.error(e)
 
-        cache_store.set(status_key, cls.Status.OPEN, ex=cls.OPEN_TTL_SECONDS)
-        return cls.Status.OPEN
+            if is_up:
+                cache_store.set(
+                    status_key, cls.Status.CLOSED, ex=cls.CLOSED_TTL_SECONDS
+                )
+                return cls.Status.CLOSED
+
+            cache_store.set(status_key, cls.Status.OPEN, ex=cls.OPEN_TTL_SECONDS)
+            return cls.Status.OPEN

--- a/docker/pyris-production.yml
+++ b/docker/pyris-production.yml
@@ -15,8 +15,11 @@ services:
         condition: service_started
     pull_policy: always
     restart: always
+    environment:
+      OPENAI_LOG: "debug"
     volumes:
       - ${PYRIS_APPLICATION_YML_FILE:-../application.example.yml}:/app/application.yml:ro
+    command: "poetry run uvicorn app.main:app --host '0.0.0.0'"
     networks:
       - pyris
 


### PR DESCRIPTION
Pyris was having severe issues in production environments when trying to use GPT4. I've been debugging this over several weeks and found 3 separate issues at play:
- A while back we added some caching for guidance objects, which guidance did not properly support in concurrent contexts -> Removed
- Guidance also does not like it if there are concurrent requests en masse, like the health check produces them -> Added a lock for the health check
- The OpenAI API returns None as the message for empty messages. Guidance did not support this -> Manually overrode guidance function