### PR TITLE
Pin Docker to 3.12.3 to fix Pydantic failure on production,

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile to build a container image for a Python 3.12 FastAPI application
-FROM python:3.12-slim
+FROM python:3.12.3-slim
 
 # Set the working directory in the container
 WORKDIR /app


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->



<!-- end of auto-generated comment: release notes by coderabbit.ai -->