### PR TITLE
Bugfix: `Set result to none after sending the result`

### DIFF
--- a/app/web/status/status_update.py
+++ b/app/web/status/status_update.py
@@ -116,6 +116,8 @@ class StatusCallback(ABC):
             raise ValueError(
                 "Invalid state transition to done. current state is ", self.stage.state
             )
+        # Reset the result after sending a final response
+        self.status.result = None
 
     def error(self, message: str):
         """


### PR DESCRIPTION
After sending a result, result field of the status update DTO should be reset, otherwise Artemis thinks a new message has been sent, if any subsequent status updates are sent.